### PR TITLE
fix: strip TypeBox optional markers from custom tool schemas

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import type { Api, Context, Model, Tool } from "@earendil-works/pi-ai";
 import { defaultProjectId, stableProjectId } from "../src/client/index.js";
 import { StopReason } from "../src/types/enums.js";
-import { ANTIGRAVITY_MODELS, getMaxOutputTokens, getAntigravityRequestModelId } from "../src/models/index.js";
+import {
+  ANTIGRAVITY_MODELS,
+  getMaxOutputTokens,
+  getAntigravityRequestModelId,
+} from "../src/models/index.js";
 import {
   buildRequest,
   convertMessages,
@@ -134,6 +138,41 @@ assert.deepEqual(openObjectDecl?.parameters, {
     label: { type: "string" },
     limit: { type: "number" },
   },
+});
+
+const typeBoxOptionalTool = {
+  name: "mcp_like",
+  description: "TypeBox optional markers must not reach the custom backend.",
+  parameters: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      limit: { type: "number", minimum: 1, "~optional": true },
+      options: {
+        type: "object",
+        properties: {
+          offset: { type: "number", minimum: 0, "~optional": true },
+        },
+        "~optional": true,
+      },
+    },
+    required: ["query"],
+  },
+} as Tool;
+const typeBoxOptionalDecl = convertTools([typeBoxOptionalTool], true)?.[0]?.functionDeclarations[0];
+assert.deepEqual(typeBoxOptionalDecl?.parameters, {
+  type: "object",
+  properties: {
+    query: { type: "string" },
+    limit: { type: "number" },
+    options: {
+      type: "object",
+      properties: {
+        offset: { type: "number" },
+      },
+    },
+  },
+  required: ["query"],
 });
 
 assert.equal(mapStopReason("STOP"), StopReason.Stop);

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -256,7 +256,7 @@ function normalizeCustomToolSchema(schema: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
-    if (CUSTOM_TOOL_SCHEMA_OMIT.has(key) || key.startsWith("$")) continue;
+    if (CUSTOM_TOOL_SCHEMA_OMIT.has(key) || key.startsWith("$") || key.startsWith("~")) continue;
     if (
       key === "enum" &&
       Array.isArray(value) &&


### PR DESCRIPTION
Strip `~` prefixed metadata keys (such as TypeBox's `~optional`) in `normalizeCustomToolSchema` to avoid sending internal schema markers to backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom tool schema handling by removing unsupported optional markers during conversion.
  - Preserved schema structure and required fields while normalizing tool definitions.
  - Continued filtering unsupported schema metadata and prefixed keys for more reliable custom-backend compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->