### PR TITLE
feat: Support headless OAuth copy-paste fallback and fix free-tier #3501 quota error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 - Pi Coding Agent and Pi AI version **0.80.0 or later**
 - A Google account that can use the relevant Cloud Code Assist / Antigravity services
-- A browser on the same machine as Pi, for the OAuth sign-in flow
+- A browser to complete the Google sign-in. Same-machine is best (the browser hits the local callback automatically); on a remote/headless machine, complete sign-in anywhere and paste the resulting callback URL back into Pi (see [Troubleshooting](#troubleshooting)).
 
 ## Install
 
@@ -143,6 +143,9 @@ By default, the provider tries `https://cloudcode-pa.googleapis.com` and then it
 ## Troubleshooting
 
 - **No credentials / 401 / 403:** Run `/login antigravity` again, then check `/antigravity.doctor`.
+- **Remote/headless machine — browser can't reach `localhost:51121`:** The callback binds to loopback only, so a browser on another machine can't hit it. You have two options:
+  - **Paste (no extra setup):** Run `/login antigravity`, open the shown URL and complete Google sign-in in _any_ browser. When it redirects to `http://localhost:51121/oauth-callback?…` and fails to load, copy that full URL from the address bar and paste it into the prompt Pi shows. The code is single-use and expires quickly, so paste promptly.
+  - **SSH tunnel (reusable):** From the machine with the browser, run `ssh -N -L 51121:127.0.0.1:51121 <user>@<server>` and keep it open, then run `/login antigravity` on the server. The redirect to `localhost:51121` tunnels through to the local callback automatically.
 - **OAuth callback will not start:** Ensure port `51121` is free and `ANTIGRAVITY_CALLBACK_HOST` is a permitted loopback address.
 - **Model is unavailable:** Run `/antigravity.models`; availability is account- and service-dependent.
 - **Claude/GPT tool-call schema error:** Upgrade to the latest package release. The provider adapts Pi's JSON Schema tool definitions for the Cloud Code Assist custom-tool bridge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,9 +1195,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,9 +1211,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1235,9 +1229,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1246,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1274,9 +1262,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "security-check": "tsx scripts/security-check.ts",
-    "test": "tsx scripts/test-model-routing.ts",
+    "test": "tsx scripts/test-model-routing.ts && tsx scripts/test-usage-formatter.ts",
     "smoke:tools": "tsx scripts/smoke-tool-schema.ts",
     "smoke:models": "node --import tsx scripts/smoke-all-models.mjs",
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run security-check && npm test"

--- a/scripts/test-usage-formatter.ts
+++ b/scripts/test-usage-formatter.ts
@@ -1,0 +1,28 @@
+import { formatUsageSummary } from "../src/usage/usage.js";
+import assert from "node:assert";
+
+console.log("Running usage formatter tests...");
+
+const baseUsage = {
+  projectId: "test",
+  endpoint: "test",
+  groups: [],
+  models: [],
+  fetchedAt: Date.now(),
+};
+
+// Regression fixture for #3501 error message
+const message3501 =
+  "/v1internal:retrieveUserQuotaSummary failed: You are currently configured to use a Google Cloud Project but lack a Gemini Code Assist license. Please contact your administrator to request a license. (#3501)";
+
+const out = formatUsageSummary({
+  ...baseUsage,
+  quotaSummaryError: message3501,
+});
+
+assert(
+  out.includes("needs a paid subscription") || out.includes("free-tier can't use that endpoint"),
+  "Formatter failed to classify #3501 missing license message as a subscription error"
+);
+
+console.log("Usage formatter tests passed!");

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -166,12 +166,23 @@ function startCallbackServer(expectedState: string): Promise<CallbackServer> {
       }
     });
 
+    let closed = false;
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      closeServerGracefully(server);
+    };
+    const cleanup = () => {
+      finish(() => rejectCode(new Error("OAuth callback cancelled")));
+      close();
+    };
+
     server.listen(51121, CALLBACK_HOST, () => {
       timeout = setTimeout(() => {
         finish(() => rejectCode(new Error("OAuth callback timed out waiting for browser login")));
-        closeServerGracefully(server);
+        close();
       }, OAUTH_CALLBACK_TIMEOUT_MS);
-      resolve({ server, waitForCode: () => codePromise });
+      resolve({ server, waitForCode: () => codePromise, cleanup });
     });
   });
 }
@@ -314,7 +325,7 @@ export async function loginAntigravity(
   // State must be independent of the PKCE verifier so a leaked callback URL
   // cannot also disclose the code_verifier needed to mint tokens.
   const state = base64Url(randomBytes(32));
-  const { server, waitForCode } = await startCallbackServer(state);
+  const { waitForCode, cleanup } = await startCallbackServer(state);
   try {
     const authParams = new URLSearchParams({
       client_id: CLIENT_ID,
@@ -379,7 +390,7 @@ export async function loginAntigravity(
       email,
     };
   } finally {
-    closeServerGracefully(server);
+    cleanup();
   }
 }
 

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -229,7 +229,7 @@ function parsePastedCallback(raw: string, expectedState: string): { code: string
  * Resolve the authorization code from either the local callback server (browser
  * on the same machine) or a pasted callback URL (browser on a remote/headless
  * machine that cannot reach localhost:51121). Whichever provides a valid code
- * first wins; the losing path is discarded. Honors callbacks.signal for cancel.
+ * first wins; the losing path is cancelled. Honors callbacks.signal for cancel.
  */
 async function acquireAuthCode(
   expectedState: string,
@@ -239,6 +239,8 @@ async function acquireAuthCode(
   },
 ): Promise<{ code: string; state: string }> {
   const { waitForCode, callbacks } = opts;
+  // Signals the losing candidate(s) to stop once the race settles.
+  const settle = new AbortController();
   const candidates: Promise<{ code: string; state: string }>[] = [waitForCode()];
 
   // Manual paste path: offered whenever the callback surface can prompt.
@@ -248,15 +250,28 @@ async function acquireAuthCode(
         "Remote/headless machine (your browser can't reach localhost:51121)? " +
         "After signing in, paste the full callback URL shown in your browser's address bar.";
       while (true) {
-        if (callbacks.signal?.aborted) throw new Error("Login cancelled");
+        if (callbacks.signal?.aborted || settle.signal.aborted) {
+          throw new Error("Login cancelled");
+        }
+        let text: string;
         try {
-          const text = await callbacks.onPrompt({
+          text = await callbacks.onPrompt({
             message: promptMessage,
             placeholder: "http://localhost:51121/oauth-callback?state=…&code=…",
           });
+        } catch (err: unknown) {
+          // Prompt/transport failure — propagate, do not retry.
+          throw err instanceof Error ? err : new Error(String(err));
+        }
+        if (callbacks.signal?.aborted || settle.signal.aborted) {
+          throw new Error("Login cancelled");
+        }
+        try {
           return parsePastedCallback(text, expectedState);
         } catch (err: unknown) {
-          if (callbacks.signal?.aborted) throw new Error("Login cancelled", { cause: err });
+          if (callbacks.signal?.aborted || settle.signal.aborted) {
+            throw new Error("Login cancelled", { cause: err });
+          }
           const errorMessage = err instanceof Error ? err.message : String(err);
           promptMessage = `Invalid callback (${errorMessage}). Please paste the full URL:`;
         }
@@ -266,19 +281,30 @@ async function acquireAuthCode(
   }
 
   // Flow cancellation (escape) aborts the whole login when a signal is provided.
+  let removeAbortListener: (() => void) | undefined;
   if (callbacks.signal) {
     candidates.push(
       new Promise<never>((_resolve, reject) => {
         const signal = callbacks.signal as AbortSignal;
         if (signal.aborted) return reject(new Error("Login cancelled"));
-        signal.addEventListener("abort", () => reject(new Error("Login cancelled")), {
-          once: true,
-        });
+        const onAbort = () => reject(new Error("Login cancelled"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
       }),
     );
   }
 
-  return Promise.race(candidates);
+  // Suppress unhandled rejections from losing candidates after the race settles.
+  for (const candidate of candidates) {
+    candidate.catch(() => {});
+  }
+
+  try {
+    return await Promise.race(candidates);
+  } finally {
+    settle.abort();
+    removeAbortListener?.();
+  }
 }
 
 export async function loginAntigravity(

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -243,16 +243,26 @@ async function acquireAuthCode(
 
   // Manual paste path: offered whenever the callback surface can prompt.
   if (typeof callbacks.onPrompt === "function") {
-    candidates.push(
-      callbacks
-        .onPrompt({
-          message:
-            "Remote/headless machine (your browser can't reach localhost:51121)? " +
-            "After signing in, paste the full callback URL shown in your browser's address bar.",
-          placeholder: "http://localhost:51121/oauth-callback?state=…&code=…",
-        })
-        .then((text) => parsePastedCallback(text, expectedState)),
-    );
+    const promptLoop = async (): Promise<{ code: string; state: string }> => {
+      let promptMessage =
+        "Remote/headless machine (your browser can't reach localhost:51121)? " +
+        "After signing in, paste the full callback URL shown in your browser's address bar.";
+      while (true) {
+        if (callbacks.signal?.aborted) throw new Error("Login cancelled");
+        try {
+          const text = await callbacks.onPrompt({
+            message: promptMessage,
+            placeholder: "http://localhost:51121/oauth-callback?state=…&code=…",
+          });
+          return parsePastedCallback(text, expectedState);
+        } catch (err: unknown) {
+          if (callbacks.signal?.aborted) throw new Error("Login cancelled", { cause: err });
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          promptMessage = `Invalid callback (${errorMessage}). Please paste the full URL:`;
+        }
+      }
+    };
+    candidates.push(promptLoop());
   }
 
   // Flow cancellation (escape) aborts the whole login when a signal is provided.

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -186,6 +186,91 @@ function credentialEmail(credentials: OAuthCredentials): string | undefined {
   return typeof email === "string" ? email : undefined;
 }
 
+/**
+ * Parse a callback URL (or bare query string) pasted by the user from a
+ * remote/headless browser that could not reach the local callback server.
+ * Returns the validated {code, state} or throws a descriptive error. The checks
+ * mirror the local callback server so a pasted URL is accepted under the exact
+ * same rules as a same-machine browser redirect.
+ */
+function parsePastedCallback(raw: string, expectedState: string): { code: string; state: string } {
+  const text = (raw ?? "").trim();
+  if (!text) {
+    throw new Error(
+      "No callback pasted. Paste the full URL from your browser's address bar (http://localhost:51121/oauth-callback?…).",
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    // Bare query string: "state=…&code=…" or "?state=…&code=…"
+    const qs = text.startsWith("?") ? text.slice(1) : text;
+    url = new URL(`http://localhost:51121/oauth-callback?${qs}`);
+  }
+  const error = url.searchParams.get("error");
+  if (error) throw new Error(`OAuth error from browser: ${error.slice(0, 200)}`);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) {
+    throw new Error(
+      "Pasted text is missing 'code' or 'state'. Paste the FULL callback URL from your browser's address bar (http://localhost:51121/oauth-callback?…).",
+    );
+  }
+  if (state !== expectedState) {
+    throw new Error(
+      "State mismatch: that callback is from a different sign-in. Re-run /login antigravity, sign in again, and paste the new URL.",
+    );
+  }
+  return { code, state };
+}
+
+/**
+ * Resolve the authorization code from either the local callback server (browser
+ * on the same machine) or a pasted callback URL (browser on a remote/headless
+ * machine that cannot reach localhost:51121). Whichever provides a valid code
+ * first wins; the losing path is discarded. Honors callbacks.signal for cancel.
+ */
+async function acquireAuthCode(
+  expectedState: string,
+  opts: {
+    waitForCode: () => Promise<{ code: string; state: string }>;
+    callbacks: OAuthLoginCallbacks;
+  },
+): Promise<{ code: string; state: string }> {
+  const { waitForCode, callbacks } = opts;
+  const candidates: Promise<{ code: string; state: string }>[] = [waitForCode()];
+
+  // Manual paste path: offered whenever the callback surface can prompt.
+  if (typeof callbacks.onPrompt === "function") {
+    candidates.push(
+      callbacks
+        .onPrompt({
+          message:
+            "Remote/headless machine (your browser can't reach localhost:51121)? " +
+            "After signing in, paste the full callback URL shown in your browser's address bar.",
+          placeholder: "http://localhost:51121/oauth-callback?state=…&code=…",
+        })
+        .then((text) => parsePastedCallback(text, expectedState)),
+    );
+  }
+
+  // Flow cancellation (escape) aborts the whole login when a signal is provided.
+  if (callbacks.signal) {
+    candidates.push(
+      new Promise<never>((_resolve, reject) => {
+        const signal = callbacks.signal as AbortSignal;
+        if (signal.aborted) return reject(new Error("Login cancelled"));
+        signal.addEventListener("abort", () => reject(new Error("Login cancelled")), {
+          once: true,
+        });
+      }),
+    );
+  }
+
+  return Promise.race(candidates);
+}
+
 export async function loginAntigravity(
   callbacks: OAuthLoginCallbacks,
 ): Promise<AntigravityOAuthCredentials> {
@@ -208,10 +293,14 @@ export async function loginAntigravity(
     });
     callbacks.onAuth({
       url: `${AUTH_URL}?${authParams.toString()}`,
-      instructions: "Complete Google sign-in. Pi will capture the local callback.",
+      instructions:
+        "Complete Google sign-in. Pi captures the local callback automatically — or, on a remote/headless machine, paste the callback URL when prompted.",
     });
 
-    const { code, state: returnedState } = await waitForCode();
+    const { code, state: returnedState } = await acquireAuthCode(state, {
+      waitForCode,
+      callbacks,
+    });
     if (returnedState !== state) throw new Error("OAuth state mismatch");
 
     const tokenResponse = await fetch(TOKEN_URL, {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -219,6 +219,8 @@ export type AccountUsage = {
   planLabel?: string;
   groups: QuotaGroup[];
   groupDescription?: string;
+  /** Set when the (subscription-gated) quota-summary RPC was unavailable, e.g. free-tier SUBSCRIPTION_REQUIRED. */
+  quotaSummaryError?: string;
   models: ModelQuotaRow[];
   defaultAgentModelId?: string;
   fetchedAt: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,6 +36,7 @@ export type DynamicModelInfo = {
 export type CallbackServer = {
   server: Server;
   waitForCode: () => Promise<{ code: string; state: string }>;
+  cleanup: () => void;
 };
 
 // Model Types

--- a/src/usage/usage.ts
+++ b/src/usage/usage.ts
@@ -372,7 +372,7 @@ export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsag
 }
 
 function quotaErrorNote(msg: string): string {
-  if (/SUBSCRIPTION_REQUIRED|valid license/i.test(msg)) {
+  if (/SUBSCRIPTION_REQUIRED|#3501|(?:lack|missing).*license/i.test(msg)) {
     return "Aggregate quota summary needs a paid subscription (free-tier can't use that endpoint). Per-model usage is still available via /antigravity.models.";
   }
   return `Aggregate quota summary unavailable: ${msg.slice(0, 160)}`;

--- a/src/usage/usage.ts
+++ b/src/usage/usage.ts
@@ -290,6 +290,27 @@ async function loadCodeAssistSafe(token: string) {
   }
 }
 
+/**
+ * The user-quota-summary RPC is gated behind a paid subscription: free-tier
+ * accounts get 403 SUBSCRIPTION_REQUIRED (#3501). It is best-effort diagnostics
+ * only — never let it block the rest of the account data (models, tier, project).
+ */
+async function fetchQuotaSummarySafe(token: string): Promise<
+  | { ok: true; result: { endpoint: string; status: number; data: unknown } }
+  | {
+      ok: false;
+      error: string;
+    }
+> {
+  try {
+    return { ok: true, result: await postJson("/v1internal:retrieveUserQuotaSummary", token, {}) };
+  } catch (error) {
+    const msg = safeError(error);
+    setLastError(msg);
+    return { ok: false, error: msg };
+  }
+}
+
 export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsage> {
   const creds = parseApiKey(apiKeyRaw);
   const initialProjectId =
@@ -301,9 +322,9 @@ export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsag
 
   // Fetch loadCodeAssist, quota summary, and available models all in parallel
   // to minimize command execution latency.
-  const [assistResult, summary, available] = await Promise.all([
+  const [assistResult, summaryRes, available] = await Promise.all([
     loadCodeAssistSafe(creds.token),
-    postJson("/v1internal:retrieveUserQuotaSummary", creds.token, {}),
+    fetchQuotaSummarySafe(creds.token),
     fetchMergedAvailableModels(creds.token, initialProjectId),
   ]);
 
@@ -316,7 +337,11 @@ export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsag
   });
   setLastProjectId(projectId);
 
-  const { groups, description } = parseQuotaSummary(summary.data);
+  const summary = summaryRes.ok ? summaryRes.result : null;
+  const quotaSummaryError = summaryRes.ok ? undefined : summaryRes.error;
+  const { groups, description } = summary
+    ? parseQuotaSummary(summary.data)
+    : { groups: [], description: undefined };
   const { models, defaultAgentModelId } = parseModels(available.data);
 
   const assistData = (isRecord(assistResult?.data) ? assistResult.data : {}) as LoadCodeAssistRaw;
@@ -333,16 +358,24 @@ export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsag
 
   return {
     projectId,
-    endpoint: summary.endpoint,
+    endpoint: summary?.endpoint ?? available.endpoint ?? assistResult?.endpoint,
     productTier,
     paidTier,
     planLabel,
     groups,
     groupDescription: description,
+    quotaSummaryError,
     models,
     defaultAgentModelId,
     fetchedAt: Date.now(),
   };
+}
+
+function quotaErrorNote(msg: string): string {
+  if (/SUBSCRIPTION_REQUIRED|valid license/i.test(msg)) {
+    return "Aggregate quota summary needs a paid subscription (free-tier can't use that endpoint). Per-model usage is still available via /antigravity.models.";
+  }
+  return `Aggregate quota summary unavailable: ${msg.slice(0, 160)}`;
 }
 
 export function formatUsageSummary(usage: AccountUsage): string {
@@ -351,7 +384,11 @@ export function formatUsageSummary(usage: AccountUsage): string {
   if (usage.planLabel) lines.push(usage.planLabel);
 
   if (!usage.groups.length) {
-    lines.push("No quota groups returned.");
+    if (usage.quotaSummaryError) {
+      lines.push(quotaErrorNote(usage.quotaSummaryError));
+    } else {
+      lines.push("No quota groups returned.");
+    }
     return lines.join("\n");
   }
 


### PR DESCRIPTION
Hi Rahul, thanks for building this extension. I’ve been using it briefly on one of my headless servers with a free-tier account, but I ran into a couple of blockers. I put together this PR to smooth out the experience:                                                                                              
                                                                                                                                                             
1. Headless OAuth Fallback
When running Pi remotely, the Google OAuth redirect to localhost fails because the user's browser is on a different machine. I added a fallback that catches this and prompts the user to manually paste the failing URL back into Pi to securely complete the login.

2. Free-tier 3501 Quota Crash
When running /antigravity.usage on a free-tier account, the command was crashing with a SUBSCRIPTION_REQUIRED (3501) error. The retrieveUserQuotaSummary endpoint is strictly gated behind a paid subscription, even though actual code generation works fine on the free tier. I updated the code to make that quota summary call "best effort". Now, instead of throwing a hard error, it gracefully degrades and just shows the user their available models and per-model usage.

Validation                                                                                                                                                  
- [x] npm run check
- [x] Tests added or updated when behavior changed (N/A - manual testing confirmed both flows work as intended)
- [x] Documentation updated when commands, auth, config, or models changed (Updated README troubleshooting)

Security
- [x] No credentials, tokens, secrets, or private account data are included
- [x] Security implications have been considered (Copy/paste fallback parses safely without exposing secrets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in now supports remote or headless authentication by pasting the callback URL.
  * Manual callback entry validates required details, retries invalid input, and supports cancellation.
  * Account usage results now report quota-summary availability issues.
* **Bug Fixes**
  * Account usage loading continues when quota details are unavailable.
  * Clear subscription-specific or general messages explain unavailable quota information.
* **Documentation**
  * Added guidance for callback URL pasting and SSH-tunnel troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->