### PR TITLE
fix: use Pi proxy dispatcher for proxied requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ By default, the provider tries `https://cloudcode-pa.googleapis.com` and then it
 
 ### Latency
 
-Provider requests reuse a long-lived keep-alive connection pool, so consecutive turns do not repeat the DNS, TCP, and TLS handshake. The pool is scoped to this provider and does not change HTTP behaviour elsewhere in Pi. The connection is also opened when the extension loads so the first message of a session skips the handshake too. For the lowest time-to-first-token, pick a fast runtime: `gemini-3.7-flash` with reasoning off routes to `gemini-3.7-flash-tiered` at thinking level `LOW`. Setting `ANTIGRAVITY_PROJECT_ID` also removes the project-discovery round-trip when credentials do not already carry a project ID.
+Provider requests reuse a long-lived keep-alive connection pool, so consecutive turns do not repeat the DNS, TCP, and TLS handshake. The pool is scoped to this provider and does not change HTTP behaviour elsewhere in Pi. When `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` is configured, requests instead use Pi's global proxy-aware dispatcher. The connection is also opened when the extension loads so the first message of a session skips the handshake too. For the lowest time-to-first-token, pick a fast runtime: `gemini-3.7-flash` with reasoning off routes to `gemini-3.7-flash-tiered` at thinking level `LOW`. Setting `ANTIGRAVITY_PROJECT_ID` also removes the project-discovery round-trip when credentials do not already carry a project ID.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "security-check": "tsx scripts/security-check.ts",
-    "test": "tsx scripts/test-model-routing.ts && tsx scripts/test-usage-formatter.ts && tsx scripts/test-stream-sse.ts",
+    "test": "tsx scripts/test-model-routing.ts && tsx scripts/test-usage-formatter.ts && tsx scripts/test-stream-sse.ts && tsx scripts/test-http-proxy.ts",
     "smoke:tools": "tsx scripts/smoke-tool-schema.ts",
     "smoke:models": "node --import tsx scripts/smoke-all-models.mjs",
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run security-check && npm test"

--- a/scripts/test-http-proxy.ts
+++ b/scripts/test-http-proxy.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { antigravityFetch } from "../src/utils/http.js";
+
+const proxyEnvNames = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
+const originalEnv = new Map(proxyEnvNames.map((name) => [name, process.env[name]]));
+const originalFetch = globalThis.fetch;
+let requestInit: RequestInit | undefined;
+
+for (const name of proxyEnvNames) delete process.env[name];
+process.env.HTTPS_PROXY = "socks5://127.0.0.1:1080";
+globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+  requestInit = init;
+  return new Response(null, { status: 204 });
+}) as typeof fetch;
+
+try {
+  const response = await antigravityFetch("https://cloudcode-pa.googleapis.com", { method: "HEAD" });
+  assert.equal(response.status, 204);
+  assert.ok(requestInit);
+  assert.equal("dispatcher" in requestInit, false);
+} finally {
+  globalThis.fetch = originalFetch;
+  for (const name of proxyEnvNames) {
+    const value = originalEnv.get(name);
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+console.log("http proxy dispatcher bypass test passed");

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -21,9 +21,19 @@ type DispatcherInit = RequestInit & { dispatcher?: unknown };
 
 let dispatcherPromise: Promise<unknown> | undefined;
 
+function hasProxyConfiguration(): boolean {
+  return ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"].some(
+    (name) => Boolean(process.env[name]?.trim()),
+  );
+}
+
 async function getDispatcher(): Promise<unknown> {
   dispatcherPromise ??= (async () => {
-    if (antigravityEnv("NO_KEEPALIVE") === "1") return undefined;
+    // Pi configures a proxy-aware global dispatcher. Passing a private Agent here
+    // would bypass it and make Antigravity requests connect directly instead.
+    if (antigravityEnv("NO_KEEPALIVE") === "1" || hasProxyConfiguration()) {
+      return undefined;
+    }
     try {
       const { Agent } = await import("undici");
       return new Agent({


### PR DESCRIPTION
# Pull request

## Summary

- defer to Pi's global proxy-aware dispatcher when `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` is configured
- retain the provider-specific keep-alive pool for direct connections
- add a regression test that verifies proxy-configured requests carry no private dispatcher
- document the proxy behavior

## Validation

- [x] `npm run check`
- [x] Tests added or updated when behavior changed
- [x] Documentation updated when commands, auth, config, or models changed

## Security

- [x] No credentials, tokens, secrets, or private account data are included
- [x] Security implications have been considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests now correctly use configured HTTP, HTTPS, or SOCKS proxies instead of bypassing them through a private connection pool.
  * Existing no-keep-alive behavior remains unchanged.

* **Tests**
  * Added coverage verifying proxy configuration is respected during HTTP requests.

* **Documentation**
  * Updated latency guidance to clarify proxy-aware request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->