### PR TITLE
fix(stream): handle missing thought_signature on cross-provider switches

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -439,6 +439,169 @@ for (const [reasoning, thinkingLevel] of [
   assert.equal(request.request.generationConfig?.thinkingConfig?.thinkingLevel, thinkingLevel);
 }
 
+// Case F: Cross-provider unsigned tool calls are converted to user observations on Gemini 3+
+const unsignedToolContext = {
+  messages: [
+    { role: "user", content: "read file", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-prev-1",
+          name: "read",
+          arguments: { path: "main.ts" },
+        },
+      ],
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-4o",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call-prev-1",
+      toolName: "read",
+      content: [{ type: "text", text: "file content" }],
+      isError: false,
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const convertedUnsigned = convertMessages(flash37Model, unsignedToolContext, "gemini-3.7-flash-tiered");
+assert.equal(convertedUnsigned.length, 1);
+assert.equal(convertedUnsigned[0]?.role, "user");
+assert.ok(convertedUnsigned[0]?.parts.some((p) => "text" in p && p.text.includes("Observation from `read`")));
+
+// Case G: Parallel tool calls where only the first call has thoughtSignature
+const validSig = "QkFTRTY0LXRlc3Qtc2lnbmF0dXJlLXRlc3QxMjM0NTY=";
+const parallelSignedContext = {
+  messages: [
+    { role: "user", content: "read two files", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-1",
+          name: "read",
+          arguments: { path: "a.ts" },
+          thoughtSignature: validSig,
+        },
+        {
+          type: "toolCall",
+          id: "call-2",
+          name: "read",
+          arguments: { path: "b.ts" },
+        },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "read",
+      content: [{ type: "text", text: "content a" }],
+      isError: false,
+      timestamp: Date.now(),
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call-2",
+      toolName: "read",
+      content: [{ type: "text", text: "content b" }],
+      isError: false,
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const convertedParallel = convertMessages(flash37Model, parallelSignedContext, "gemini-3.7-flash-tiered");
+assert.equal(convertedParallel.length, 3);
+assert.equal(convertedParallel[1]?.role, "model");
+assert.equal(convertedParallel[1]?.parts.length, 2);
+assert.ok(convertedParallel[1]?.parts.every((p) => "functionCall" in p), "all parallel calls in signed turn remain functionCalls");
+assert.equal(convertedParallel[2]?.role, "user");
+assert.equal(convertedParallel[2]?.parts.length, 2);
+assert.ok(convertedParallel[2]?.parts.every((p) => "functionResponse" in p), "all parallel results remain functionResponses");
+
+// Case H: Parallel tool calls with reversed signature placement (first unsigned, second signed)
+const parallelReversedContext = {
+  messages: [
+    { role: "user", content: "read files", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "call-r1", name: "read", arguments: { path: "a.ts" } },
+        { type: "toolCall", id: "call-r2", name: "read", arguments: { path: "b.ts" }, thoughtSignature: validSig },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    { role: "toolResult", toolCallId: "call-r1", toolName: "read", content: [{ type: "text", text: "a" }], isError: false, timestamp: Date.now() },
+    { role: "toolResult", toolCallId: "call-r2", toolName: "read", content: [{ type: "text", text: "b" }], isError: false, timestamp: Date.now() },
+  ],
+} as unknown as Context;
+const convertedReversed = convertMessages(flash37Model, parallelReversedContext, "gemini-3.7-flash-tiered");
+assert.ok(!convertedReversed.some((c) => c.parts.some((p) => "functionCall" in p)), "reversed signature calls downgrade to observations");
+
+// Case I: Signed thinking block with unsigned tool call
+const signedThinkingUnsignedCallContext = {
+  messages: [
+    { role: "user", content: "do action", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "plan", thinkingSignature: validSig },
+        { type: "toolCall", id: "call-u1", name: "read", arguments: { path: "a.ts" } },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    { role: "toolResult", toolCallId: "call-u1", toolName: "read", content: [{ type: "text", text: "result" }], isError: false, timestamp: Date.now() },
+  ],
+} as unknown as Context;
+const convertedSignedThinking = convertMessages(flash37Model, signedThinkingUnsignedCallContext, "gemini-3.7-flash-tiered");
+assert.ok(!convertedSignedThinking.some((c) => c.parts.some((p) => "functionCall" in p)), "thinking signature does not mark unsigned toolCall as signed");
+
+// Case J: Sibling call with malformed/corrupted signature
+const malformedSiblingContext = {
+  messages: [
+    { role: "user", content: "read files", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "call-m1", name: "read", arguments: { path: "a.ts" }, thoughtSignature: validSig },
+        { type: "toolCall", id: "call-m2", name: "read", arguments: { path: "b.ts" }, thoughtSignature: "invalid!!base64" },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    { role: "toolResult", toolCallId: "call-m1", toolName: "read", content: [{ type: "text", text: "a" }], isError: false, timestamp: Date.now() },
+    { role: "toolResult", toolCallId: "call-m2", toolName: "read", content: [{ type: "text", text: "b" }], isError: false, timestamp: Date.now() },
+  ],
+} as unknown as Context;
+const convertedMalformed = convertMessages(flash37Model, malformedSiblingContext, "gemini-3.7-flash-tiered");
+assert.ok(!convertedMalformed.some((c) => c.parts.some((p) => "functionCall" in p)), "malformed sibling signature causes downgrade to observation");
+
 console.log(
   `model routing: ${routeCases.length} cases, tool schema, errors, project ids, token clamping, and message conversion passed`,
 );

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -90,6 +90,23 @@ function toolCallIdNeeded(modelId: string, runtimeModel: string): boolean {
   );
 }
 
+const base64SignaturePattern = /^[A-Za-z0-9+/]+={0,2}$/;
+function isValidThoughtSignature(signature?: string): boolean {
+  if (!signature || typeof signature !== "string" || signature.length === 0) return false;
+  if (signature.length % 4 !== 0) return false;
+  return base64SignaturePattern.test(signature);
+}
+
+function geminiRequiresThoughtSignature(runtimeModel: string): boolean {
+  if (!runtimeModel.startsWith("gemini-")) return false;
+  const match = runtimeModel.match(/^gemini-(\d+)/);
+  if (match) {
+    const major = Number.parseInt(match[1], 10);
+    return major >= 3;
+  }
+  return true;
+}
+
 function parseImageData(raw: string, explicitMime?: string): { data: string; mimeType: string } {
   const match = raw.match(/^data:([^;]+);base64,(.+)$/s);
   if (match) {
@@ -139,17 +156,44 @@ export function convertMessages(
   runtimeModel: string,
 ): GeminiContent[] {
   const contents: GeminiContent[] = [];
+  const requiresSig = geminiRequiresThoughtSignature(runtimeModel);
+  // Map unsigned toolCall IDs to their argument strings.
+  // Their paired toolResults are converted into user observations without emitting
+  // pseudo-code text in the model turn (which prevents Gemini from mimicking text calls).
+  const droppedToolCallIds = new Map<string, string>();
   for (const msg of context.messages) {
     if (msg.role === "user") {
       const parts = asTextParts(msg.content);
       appendTurn(contents, GeminiRole.User, parts);
     } else if (msg.role === "assistant") {
       const parts: GeminiPart[] = [];
+      const isSameModel = msg.provider === PROVIDER_ID && msg.model === model.id;
+      const toolCalls = msg.content.filter((b): b is ToolCall => b.type === "toolCall");
+      // In parallel function calling, Gemini places thoughtSignature only on the first call.
+      // A tool-call group is valid only when originating from compatible Gemini history and
+      // the first call carries a valid signature, with no malformed signatures on sibling calls.
+      const firstCallHasSig =
+        toolCalls.length > 0 && isValidThoughtSignature(toolCalls[0]?.thoughtSignature);
+      const allSigsValid = toolCalls.every(
+        (tc) => !tc.thoughtSignature || isValidThoughtSignature(tc.thoughtSignature),
+      );
+      const groupIsSigned = isSameModel && firstCallHasSig && allSigsValid;
+
       for (const block of msg.content) {
-        if (block.type === "text" && String(block.text || "").trim()) {
-          parts.push({ text: sanitizeText(block.text) });
+        if (block.type === "text") {
+          const textSig =
+            isSameModel && isValidThoughtSignature(block.textSignature)
+              ? block.textSignature
+              : undefined;
+          if ((!block.text || block.text.trim() === "") && !textSig) {
+            continue;
+          }
+          parts.push({
+            text: sanitizeText(block.text),
+            ...(textSig ? { thoughtSignature: textSig } : {}),
+          });
         } else if (block.type === "thinking" && String(block.thinking || "").trim()) {
-          if (msg.provider === PROVIDER_ID && msg.model === model.id) {
+          if (isSameModel) {
             parts.push({
               thought: true,
               text: sanitizeText(block.thinking),
@@ -159,16 +203,41 @@ export function convertMessages(
             parts.push({ text: sanitizeText(block.thinking) });
           }
         } else if (block.type === "toolCall") {
-          parts.push({
-            functionCall: {
-              name: block.name,
-              args: block.arguments ?? {},
-              ...(toolCallIdNeeded(model.id, runtimeModel)
-                ? { id: sanitizeToolCallId(block.id || "", block.name) }
-                : {}),
-            },
-            ...(block.thoughtSignature ? { thoughtSignature: block.thoughtSignature } : {}),
-          });
+          const isSigned = groupIsSigned;
+          // Gemini 3+ with thinking requires thoughtSignature on every functionCall.
+          // Cross-provider history (or any history without a valid sig) would 400:
+          //   "Function call is missing a thought_signature ... position 136"
+          // See: https://ai.google.dev/gemini-api/docs/thought-signatures
+          // When missing, record the call so the corresponding toolResult is rendered as an
+          // observation in the user turn without emitting a pseudo-code model turn that trains
+          // Gemini to emit text calls.
+          if (requiresSig && !isSigned) {
+            const rawId = block.id || "";
+            const argsText = (() => {
+              try {
+                return JSON.stringify(block.arguments ?? {});
+              } catch {
+                return "{}";
+              }
+            })();
+            if (rawId) {
+              droppedToolCallIds.set(rawId, argsText);
+              droppedToolCallIds.set(sanitizeToolCallId(rawId, block.name), argsText);
+            } else {
+              droppedToolCallIds.set(`empty:${block.name}`, argsText);
+            }
+          } else {
+            parts.push({
+              functionCall: {
+                name: block.name,
+                args: block.arguments ?? {},
+                ...(toolCallIdNeeded(model.id, runtimeModel)
+                  ? { id: sanitizeToolCallId(block.id || "", block.name) }
+                  : {}),
+              },
+              ...(block.thoughtSignature ? { thoughtSignature: block.thoughtSignature } : {}),
+            });
+          }
         }
       }
       appendTurn(contents, GeminiRole.Model, parts);
@@ -178,16 +247,33 @@ export function convertMessages(
         .map((c) => sanitizeText(c.text))
         .join("\n");
       const responseText = text || (msg.isError ? "Tool failed" : "");
-      const part: GeminiFunctionResponsePart = {
-        functionResponse: {
-          name: msg.toolName,
-          response: msg.isError ? { error: responseText } : { output: responseText },
-          ...(toolCallIdNeeded(model.id, runtimeModel)
-            ? { id: sanitizeToolCallId(msg.toolCallId || "", msg.toolName) }
-            : {}),
-        },
-      };
-      appendTurn(contents, GeminiRole.User, [part]);
+      const rawId = msg.toolCallId || "";
+      const sanitizedId = toolCallIdNeeded(model.id, runtimeModel)
+        ? sanitizeToolCallId(rawId, msg.toolName)
+        : rawId;
+      const droppedArgs = requiresSig
+        ? (droppedToolCallIds.get(rawId) ??
+          droppedToolCallIds.get(sanitizedId) ??
+          (rawId === "" ? droppedToolCallIds.get(`empty:${msg.toolName}`) : undefined))
+        : undefined;
+      if (droppedArgs !== undefined) {
+        const label =
+          droppedArgs === "{}" ? `\`${msg.toolName}\`` : `\`${msg.toolName}\` (${droppedArgs})`;
+        appendTurn(contents, GeminiRole.User, [
+          { text: sanitizeText(`[Observation from ${label}:\n${responseText}]`) },
+        ]);
+      } else {
+        const part: GeminiFunctionResponsePart = {
+          functionResponse: {
+            name: msg.toolName,
+            response: msg.isError ? { error: responseText } : { output: responseText },
+            ...(toolCallIdNeeded(model.id, runtimeModel)
+              ? { id: sanitizeToolCallId(msg.toolCallId || "", msg.toolName) }
+              : {}),
+          },
+        };
+        appendTurn(contents, GeminiRole.User, [part]);
+      }
     }
   }
 


### PR DESCRIPTION
# Pull request

## Summary

- Downgrade prior tool calls and paired tool results lacking a thought signature to plain text when converting history for Gemini 3+ models.
- Add test coverage for cross-provider tool call conversion in `scripts/test-model-routing.ts`.

## Problem

When switching to `antigravity/gemini-3.7-flash` (or other Gemini 3+ models) in a session where another provider (such as Claude or OpenAI) previously called tools, Google rejects the request with a 400 error:
```text
Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly...
```
Google's Gemini 3+ API requires an encrypted `thought_signature` on replayed `functionCall` parts when thinking is on. Previous tool calls from other models do not have Google thought signatures. Converting unsigned calls to text preserves the conversation history without triggering the 400 rejection.

## Validation

- [x] `npm run check` (typecheck, lint, format, security checks, tests)
- [x] Unit test added in `scripts/test-model-routing.ts` verifying unsigned tool calls convert to text on Gemini 3+.

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling Gemini tool calls, including parallel calls and unsigned calls from other providers.
  * Preserved images returned by tools and prevented invalid or incomplete assistant messages from being replayed.
  * Improved handling of Gemini reasoning settings across supported runtimes, including tiered requests.

* **Improvements**
  * Streaming responses now provide more accurate stop reasons and reasoning-token usage.
  * Error messages include additional provider details to make failures easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->