### PR TITLE
fix(stream): preserve rawStopReason and error diagnostics on error stops

### DIFF
--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -144,6 +144,10 @@ export function convertMessages(
       const parts = asTextParts(msg.content);
       appendTurn(contents, GeminiRole.User, parts);
     } else if (msg.role === "assistant") {
+      // Skip errored/aborted turns during replay so incomplete calls do not cause cascading errors.
+      if (msg.stopReason === "error" || msg.stopReason === "aborted") {
+        continue;
+      }
       const parts: GeminiPart[] = [];
       for (const block of msg.content) {
         if (block.type === "text" && String(block.text || "").trim()) {
@@ -678,6 +682,7 @@ export async function streamResponse(
       }
 
       if (candidate?.finishReason) {
+        output.rawStopReason = candidate.finishReason;
         output.stopReason = blocks.some((b) => b.type === "toolCall")
           ? StopReason.ToolUse
           : mapStopReason(candidate.finishReason);
@@ -872,6 +877,11 @@ export function streamAntigravity(
       if (!received) throw new Error("Antigravity API returned an empty response");
       setLastLatencyMs(Date.now() - startTime);
       if (output.stopReason === "error" || output.stopReason === "aborted") {
+        const errorDetail = output.rawStopReason
+          ? `Provider stopped with: ${output.rawStopReason}`
+          : "An unknown error occurred";
+        output.errorMessage = output.errorMessage || errorDetail;
+        setLastError(output.errorMessage);
         stream.push({ type: "error", reason: output.stopReason, error: output });
       } else if (output.stopReason === "pending") {
         throw new Error("Antigravity API returned no stop reason");


### PR DESCRIPTION
# Pull request

## Summary

- Capture `output.rawStopReason` from `candidate.finishReason`.
- Set `output.errorMessage` when a stream stops on an error reason, avoiding generic "Unknown error" UI messages.
- Skip errored and aborted assistant turns in history replay so incomplete tool calls are not replayed on following turns.

## Problem

When Google terminates a generation early with a non-stop finishReason (such as `MALFORMED_FUNCTION_CALL`, `SAFETY`, or `SPII`), `streamResponse` was mapping to `stopReason: "error"` without populating `rawStopReason` or `errorMessage`. Pi then fell back to displaying "Unknown error" in the chat transcript.

Additionally, replaying errored or aborted assistant turns into subsequent requests can cause repeated 400 errors because the turn was incomplete. Skipping them follows `@earendil-works/pi-ai` message transformation conventions.

## Validation

- [x] `npm run check` (typecheck, lint, format, security-check, tests)

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.
