### PR TITLE
feat(stream): include thoughts in Gemini thinkingConfig and avoid prompt leaks

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -422,7 +422,7 @@ const reqD = buildRequest(
 );
 assert.equal(reqD.request.generationConfig?.maxOutputTokens, 65535);
 
-// Case E: Gemini 3.7 uses its tiered runtime and sends effort in thinkingConfig.
+// Case E: Gemini 3.7 uses its tiered runtime and sends effort in thinkingConfig with includeThoughts: true.
 const flash37Model = { ...model, id: "gemini-3.7-flash", maxTokens: 65536 };
 for (const [reasoning, thinkingLevel] of [
   ["low", "LOW"],
@@ -437,7 +437,42 @@ for (const [reasoning, thinkingLevel] of [
     "gemini-3.7-flash-tiered",
   );
   assert.equal(request.request.generationConfig?.thinkingConfig?.thinkingLevel, thinkingLevel);
+  assert.equal(request.request.generationConfig?.thinkingConfig?.includeThoughts, true);
 }
+
+// Case F: Gemini 3.7 with reasoning "off" sets thinkingLevel: LOW without includeThoughts
+const reqOff = buildRequest(
+  flash37Model,
+  dummyContext,
+  "test-proj",
+  { reasoning: "off" },
+  "gemini-3.7-flash-tiered",
+);
+assert.equal(reqOff.request.generationConfig?.thinkingConfig?.thinkingLevel, "LOW");
+assert.equal(reqOff.request.generationConfig?.thinkingConfig?.includeThoughts, undefined);
+
+// Case G: Cross-model thinking blocks are dropped to prevent prompt pollution
+const crossThinkingContext = {
+  messages: [
+    { role: "user", content: "hi", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "cross model internal monologue" },
+        { type: "text", text: "visible answer" },
+      ],
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const convertedCross = convertMessages(flash37Model, crossThinkingContext, "gemini-3.7-flash-tiered");
+assert.equal(convertedCross[1]?.parts.length, 1);
+assert.deepEqual(convertedCross[1]?.parts[0], { text: "visible answer" });
 
 console.log(
   `model routing: ${routeCases.length} cases, tool schema, errors, project ids, token clamping, and message conversion passed`,

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -155,9 +155,9 @@ export function convertMessages(
               text: sanitizeText(block.thinking),
               ...(block.thinkingSignature ? { thoughtSignature: block.thinkingSignature } : {}),
             });
-          } else {
-            parts.push({ text: sanitizeText(block.thinking) });
           }
+          // Cross-model thinking blocks are dropped rather than converted to assistant text
+          // to prevent Gemini from mimicking older models' thought monologues in its final text response.
         } else if (block.type === "toolCall") {
           parts.push({
             functionCall: {
@@ -393,9 +393,11 @@ export function buildRequest(
   if (options.temperature !== undefined) generationConfig.temperature = options.temperature;
   if (runtimeModel === "gemini-3.7-flash-tiered") {
     const effort = options.reasoning ?? "off";
+    const thinkingLevel =
+      effort === "high" || effort === "xhigh" ? "HIGH" : effort === "medium" ? "MEDIUM" : "LOW";
     generationConfig.thinkingConfig = {
-      thinkingLevel:
-        effort === "high" || effort === "xhigh" ? "HIGH" : effort === "medium" ? "MEDIUM" : "LOW",
+      thinkingLevel,
+      ...(effort !== "off" ? { includeThoughts: true } : {}),
     };
   }
   const maxAllowed = getMaxOutputTokens(model.id, runtimeModel);
@@ -691,6 +693,7 @@ export async function streamResponse(
           (responseData.usageMetadata.candidatesTokenCount || 0) +
           (responseData.usageMetadata.thoughtsTokenCount || 0);
         output.usage.cacheRead = cacheRead;
+        output.usage.reasoning = responseData.usageMetadata.thoughtsTokenCount || 0;
         output.usage.totalTokens = responseData.usageMetadata.totalTokenCount || 0;
         // Keep subscription costs at zero (matches model catalog freeCost).
         output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -105,7 +105,8 @@ export type GeminiGenerationConfig = {
   temperature?: number;
   maxOutputTokens?: number;
   thinkingConfig?: {
-    thinkingLevel: "LOW" | "MEDIUM" | "HIGH";
+    includeThoughts?: boolean;
+    thinkingLevel?: "LOW" | "MEDIUM" | "HIGH";
   };
 };
 


### PR DESCRIPTION
# Pull request

## Summary

- Add `includeThoughts: true` to `thinkingConfig` for `gemini-3.7-flash-tiered` when reasoning is enabled.
- Drop cross-model thinking blocks from prompt history during message conversion so Gemini does not mimic older models' thought monologues in its final text output.
- Record `output.usage.reasoning` from `usageMetadata.thoughtsTokenCount`.

## Problem

Cloud Code Assist requires `includeThoughts: true` in `thinkingConfig` to stream `thought: true` deltas in the SSE response. Without this flag, Google suppresses thought parts so Pi cannot render thinking blocks.

Additionally, converting prior models' thinking blocks into plain assistant text caused Gemini to copy that pattern and write its reasoning directly into the text response. Dropping foreign thinking blocks avoids this prompt pollution.

## Demonstration

<img width="3174" height="386" alt="image" src="https://github.com/user-attachments/assets/c01c0062-fc7d-429c-967c-1562445bb35a" />

## Validation

- [x] `npm run check` (typecheck, lint, format, security-check, tests)
- [x] Unit tests added in `scripts/test-model-routing.ts` for `includeThoughts` gating and cross-model thinking block filtering.

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.
