### PR TITLE
feat(stream): support multimodal tool results (images from tools)

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -439,6 +439,47 @@ for (const [reasoning, thinkingLevel] of [
   assert.equal(request.request.generationConfig?.thinkingConfig?.thinkingLevel, thinkingLevel);
 }
 
+// Case F: Multimodal tool results preserve images alongside text
+const multimodalResultContext = {
+  messages: [
+    { role: "user", content: "take screenshot", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-shot",
+          name: "screenshot",
+          arguments: {},
+        },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call-shot",
+      toolName: "screenshot",
+      content: [
+        { type: "text", text: "captured" },
+        { type: "image", data: "data:image/png;base64,iVBORw0KGgo=", mimeType: "image/png" },
+      ],
+      isError: false,
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const convertedMultimodal = convertMessages(flash37Model, multimodalResultContext, "gemini-3.7-flash-tiered");
+assert.equal(convertedMultimodal.length, 3);
+assert.equal(convertedMultimodal[2]?.role, "user");
+assert.equal(convertedMultimodal[2]?.parts.length, 2);
+assert.ok(convertedMultimodal[2]?.parts.some((p) => "functionResponse" in p));
+assert.ok(convertedMultimodal[2]?.parts.some((p) => "inlineData" in p && p.inlineData.mimeType === "image/png"));
+
 console.log(
   `model routing: ${routeCases.length} cases, tool schema, errors, project ids, token clamping, and message conversion passed`,
 );

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -122,6 +122,22 @@ function asTextParts(content: unknown): Array<GeminiTextPart | GeminiInlineDataP
   });
 }
 
+function asImageParts(content: unknown): GeminiInlineDataPart[] {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((item): GeminiInlineDataPart[] => {
+    if (!isRecord(item)) return [];
+    const block = item as ContentBlock;
+    if (block.type === "image") {
+      const rawData = block.data || block.source?.data;
+      if (!rawData) return [];
+      const explicitMime = block.mimeType || block.mediaType || block.source?.mediaType;
+      const { data, mimeType } = parseImageData(rawData, explicitMime);
+      return data ? [{ inlineData: { mimeType, data } }] : [];
+    }
+    return [];
+  });
+}
+
 function appendTurn(contents: GeminiContent[], role: GeminiRole, parts: GeminiPart[]): void {
   if (!parts.length) return;
   const last = contents[contents.length - 1];
@@ -178,6 +194,7 @@ export function convertMessages(
         .map((c) => sanitizeText(c.text))
         .join("\n");
       const responseText = text || (msg.isError ? "Tool failed" : "");
+      const imageParts = asImageParts(msg.content);
       const part: GeminiFunctionResponsePart = {
         functionResponse: {
           name: msg.toolName,
@@ -187,7 +204,7 @@ export function convertMessages(
             : {}),
         },
       };
-      appendTurn(contents, GeminiRole.User, [part]);
+      appendTurn(contents, GeminiRole.User, [part, ...imageParts]);
     }
   }
 


### PR DESCRIPTION
# Pull request

## Summary

- Parse `image` blocks in `toolResult` messages and attach them as `inlineData` parts in the user turn.
- Add unit test coverage in `scripts/test-model-routing.ts`.

## Problem

When a tool returns an image (for example, browser automation screenshots or chart outputs), `convertMessages` previously only filtered for `type === "text"`, silently discarding all image blocks. Gemini vision models were left unable to see image outputs produced by tools.

Preserving `inlineData` in tool responses matches how `@earendil-works/pi-ai` handles multimodal function results.

## Validation

- [x] `npm run check` (typecheck, lint, format, security-check, tests)
- [x] Added unit test verifying image parts in tool results are preserved as `inlineData`.

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.
