### PR TITLE
perf(stream): use deterministic fallback tool call IDs for prompt cache stability

### DIFF
--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -78,7 +78,7 @@ let toolCallCounter = 0;
 function sanitizeToolCallId(id: string, fallbackName?: string): string {
   const cleaned = id.replace(/[^a-zA-Z0-9_-]/g, "_");
   const capped = cleaned.slice(0, 64);
-  return capped || `${fallbackName || "tool"}_${Date.now()}_${++toolCallCounter}`;
+  return capped || `${fallbackName || "tool"}_${++toolCallCounter}`;
 }
 
 function toolCallIdNeeded(modelId: string, runtimeModel: string): boolean {


### PR DESCRIPTION
# Pull request

## Summary

- Remove `Date.now()` from fallback tool call ID generation in `sanitizeToolCallId`.

## Problem

Google Gemini uses implicit server-side prefix caching. On every new turn, Pi re-runs `convertMessages` across the full conversation history.

For tool calls without an explicit ID, `sanitizeToolCallId` previously generated a new ID with `Date.now()` on every request. This mutated previous turns on every single turn, invalidating Google's prompt cache for the rest of the session. Removing `Date.now()` ensures past turns remain byte-identical across requests, preserving prompt cache hits.

## Validation

- [x] `npm run check` (typecheck, lint, format, security-check, tests)

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.
