### PR TITLE
fix: avoid undici dispatcher mismatch on Node 22+ and fallback to native fetch

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -34,6 +34,12 @@ async function getDispatcher(): Promise<unknown> {
     if (antigravityEnv("NO_KEEPALIVE") === "1" || hasProxyConfiguration()) {
       return undefined;
     }
+    // Node.js native fetch in Node 22+ manages connection pooling and keep-alive natively,
+    // and passing external npm undici Agent instances causes onRequestStart interface mismatches.
+    const nodeMajor = Number(process.versions.node?.split(".")[0]);
+    if (!Number.isNaN(nodeMajor) && nodeMajor >= 22) {
+      return undefined;
+    }
     try {
       const { Agent } = await import("undici");
       return new Agent({
@@ -60,7 +66,12 @@ export async function antigravityFetch(
 ): Promise<Response> {
   const dispatcher = await getDispatcher();
   if (!dispatcher) return fetch(input, init);
-  return fetch(input, { ...init, dispatcher } as DispatcherInit);
+  try {
+    return await fetch(input, { ...init, dispatcher } as DispatcherInit);
+  } catch {
+    // If the custom dispatcher fails (e.g. undici/runtime mismatch), fall back to native fetch.
+    return fetch(input, init);
+  }
 }
 
 /**


### PR DESCRIPTION
### Problem
Under Node.js 22/24 (e.g. Node 24.16.0), passing an external `npm:undici` `Agent` instance to Node's built-in global `fetch` via `{ dispatcher }` throws:
```
TypeError: fetch failed
[cause]: InvalidArgumentError: invalid onRequestStart method
```
This occurs in environments without proxy configurations because Node's internal undici implementation has internal handler interface mismatches with external `undici.Agent` instances.

### Solution
1. Skip instantiating a custom `undici.Agent` on Node 22+ where Node's built-in `fetch` already manages keep-alive connection pooling natively.
2. Add a `try ... catch` fallback in `antigravityFetch` so that if custom dispatcher execution ever fails due to a runtime/undici mismatch, it gracefully falls back to native `fetch(input, init)` rather than failing the request.

### Verification
- `npm run check` passed (typecheck, lint, prettier, security check, test suites).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request reliability on Node.js 22 and later.
  * Added a fallback to the standard fetch behavior when custom connection handling encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->