### PR TITLE
fix: register antigravity-api with @earendil-works/pi-ai/compat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { registerApiProvider } from "@earendil-works/pi-ai/compat";
 import { getApiKey, loginAntigravity, refreshAntigravityToken } from "./auth/index.js";
 import { DEFAULT_ENDPOINT, endpointCandidates } from "./client/index.js";
 import { getLastDiagnostics, runWithDiagnostics } from "./diagnostics/index.js";
@@ -57,6 +58,12 @@ export default function (pi: ExtensionAPI): void {
   // the handshake. Opt out with ANTIGRAVITY_NO_PREWARM=1.
   const primaryEndpoint = endpointCandidates()[0];
   if (primaryEndpoint) prewarmConnection(primaryEndpoint);
+
+  registerApiProvider({
+    api: ANTIGRAVITY_API,
+    stream: streamAntigravity as any,
+    streamSimple: streamAntigravity,
+  });
 
   pi.registerProvider(PROVIDER_ID, {
     name: PROVIDER_NAME,


### PR DESCRIPTION
### Summary

Registers `antigravity-api` via `registerApiProvider` from `@earendil-works/pi-ai/compat` on extension startup.

### Context & Motivation

Extensions and plugins like `pi-condense` (or other tooling in the Pi ecosystem) that call `stream(model)` using `@earendil-works/pi-ai/compat` rely on the static `apiProviderRegistry`. Without this registration, using Antigravity models for summarization, fallback, or subagents throws:
```
Error: No API provider registered for api: antigravity-api
```

Registering `streamAntigravity` with the compat API provider registry ensures custom API calls via `pi-ai` resolve and execute correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Antigravity API provider.
  * Enabled streaming and standard response handling for Antigravity requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->