### PR TITLE
feat(models): add API pricing rates for live cost tracking

### DIFF
--- a/scripts/test-stream-sse.ts
+++ b/scripts/test-stream-sse.ts
@@ -78,10 +78,10 @@ function splitEvery(text: string, size: number): string[] {
   return out;
 }
 
-async function run(chunks: string[]) {
+async function run(chunks: string[], model?: Model<Api>) {
   const stream = createAssistantMessageEventStream();
   const output = makeOutput();
-  const hasContent = await streamResponse(responseFromChunks(chunks), stream, output);
+  const hasContent = await streamResponse(responseFromChunks(chunks), stream, output, model);
   stream.end();
   const events: string[] = [];
   for await (const event of stream) events.push(event.type);
@@ -139,6 +139,23 @@ async function main() {
   const truncated = BODY.slice(0, BODY.lastIndexOf("data: [DONE]"));
   const { hasContent } = await run([truncated.slice(0, 40), truncated.slice(40)]);
   assert(hasContent, "truncated body: expected content");
+
+  // Verify cost calculation when model is provided
+  const dummyModel = {
+    id: "gemini-3.7-flash",
+    cost: { input: 0.1, output: 0.4, cacheRead: 0.025, cacheWrite: 0.1 },
+  } as Model<Api>;
+  const costRun = await run([BODY], dummyModel);
+  // input: 60 -> (0.1/1e6)*60 = 0.000006, cacheRead: 40 -> (0.025/1e6)*40 = 0.000001, output: 10 -> (0.4/1e6)*10 = 0.000004
+  // total: 0.000011
+  assert(Math.abs(costRun.output.usage.cost.total - 0.000011) < 1e-9, "cost calculation matches expected total");
+  assert(Math.abs(costRun.output.usage.cost.input - 0.000006) < 1e-9, "cost calculation matches expected input");
+
+  // Verify graceful fallback when model or model.cost is omitted
+  const noCostModel = { id: "unknown-custom" } as Model<Api>;
+  const noCostRun = await run([BODY], noCostModel);
+  assert(noCostRun.output.usage.cost.total === 0, "omitted cost defaults total to 0");
+  assert(noCostRun.output.usage.cost.input === 0, "omitted cost defaults input to 0");
 
   console.log(`stream SSE: ${sizes.length} chunk-boundary cases passed`);
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -148,7 +148,11 @@ export function getMaxOutputTokens(modelId: string, runtimeModel?: string): numb
   return 8192;
 }
 
-const freeCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+const geminiFlashCost = { input: 0.1, output: 0.4, cacheRead: 0.025, cacheWrite: 0.1 };
+const geminiProCost = { input: 1.25, output: 5.0, cacheRead: 0.3125, cacheWrite: 1.25 };
+const claudeSonnetCost = { input: 3.0, output: 15.0, cacheRead: 0.3, cacheWrite: 3.75 };
+const claudeOpusCost = { input: 15.0, output: 75.0, cacheRead: 1.5, cacheWrite: 18.75 };
+const gptOssCost = { input: 0.6, output: 2.4, cacheRead: 0.15, cacheWrite: 0.6 };
 
 // A null entry is intentionally hidden by Pi. Do not collapse levels that happen to
 // route to the same runtime ID: the UI must reflect the levels the backend advertises.
@@ -199,7 +203,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.lowMediumHigh,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: geminiFlashCost,
     contextWindow: 1048576,
     maxTokens: 65536,
   },
@@ -209,7 +213,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.lowMediumHigh,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: geminiFlashCost,
     contextWindow: 1048576,
     maxTokens: 65536,
   },
@@ -219,7 +223,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.thinking,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: claudeOpusCost,
     contextWindow: 250000,
     maxTokens: 64000,
   },
@@ -229,7 +233,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.thinking,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: claudeSonnetCost,
     contextWindow: 200000,
     maxTokens: 64000,
   },
@@ -239,7 +243,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.lowHigh,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: geminiProCost,
     contextWindow: 1048576,
     maxTokens: 65535,
   },
@@ -249,7 +253,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.lowMediumHigh,
     input: ["text", "image"],
-    cost: freeCost,
+    cost: geminiFlashCost,
     contextWindow: 1048576,
     maxTokens: 65536,
   },
@@ -259,7 +263,7 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
     reasoning: true,
     thinkingLevelMap: thinkingLevelMaps.medium,
     input: ["text"],
-    cost: freeCost,
+    cost: gptOssCost,
     contextWindow: 131072,
     maxTokens: 32768,
   },

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -1,4 +1,5 @@
 import {
+  calculateCost,
   createAssistantMessageEventStream,
   type Api,
   type AssistantMessage,
@@ -624,6 +625,7 @@ export async function streamResponse(
   response: Response,
   stream: AssistantMessageEventStream,
   output: AssistantMessage,
+  model?: Model<Api>,
 ): Promise<boolean> {
   if (!response.body) throw new Error("No response body");
   const reader = response.body.getReader();
@@ -777,8 +779,11 @@ export async function streamResponse(
         output.usage.reasoning = thoughts;
         output.usage.cacheRead = cacheRead;
         output.usage.totalTokens = responseData.usageMetadata.totalTokenCount || 0;
-        // Keep subscription costs at zero (matches model catalog freeCost).
-        output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        if (model?.cost) {
+          calculateCost(model, output.usage);
+        } else {
+          output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        }
       }
     }
 
@@ -951,7 +956,7 @@ export function streamAntigravity(
         };
         output.stopReason = "stop";
 
-        received = await streamResponse(response, stream, output);
+        received = await streamResponse(response, stream, output, model);
         if (received) break;
       }
 


### PR DESCRIPTION
# Pull request

## Summary

- Add standard pricing rates to `ANTIGRAVITY_MODELS` in `src/models/models.ts`.
- Call `@earendil-works/pi-ai`'s `calculateCost(model, output.usage)` in `src/stream/stream.ts` when usage metadata is received.
- Add test coverage in `scripts/test-stream-sse.ts` verifying cost computation from stream chunks.

## Problem

Antigravity models previously defaulted to zero cost (`freeCost`), which left Pi's statusline cost meter and session telemetry at `$0.00` indefinitely.

Other subscription-backed providers in Pi (such as `openai-codex` and `github-copilot`) track standard API equivalent rates so users have real-time visibility into token spend. Adding standard rates enables live cost tracking on Pi's statusline and gives users direct intuition for quota consumption across models (such as Flash vs. Pro vs. Claude Opus) and cache discounts.

### Configured rates (USD per 1M tokens)

- **Gemini Flash (`3.7`, `3.6`, `3.5`)**: `$0.10` input, `$0.40` output, `$0.025` cache read, `$0.10` cache write
- **Gemini Pro (`3.1`)**: `$1.25` input, `$5.00` output, `$0.3125` cache read, `$1.25` cache write
- **Claude Sonnet (`4.6`)**: `$3.00` input, `$15.00` output, `$0.30` cache read, `$3.75` cache write
- **Claude Opus (`4.6`)**: `$15.00` input, `$75.00` output, `$1.50` cache read, `$18.75` cache write
- **GPT-OSS (`120B`)**: `$0.60` input, `$2.40` output, `$0.15` cache read, `$0.60` cache write

## Validation

- [x] `bun run check` (typecheck, lint, format, security-check, tests)
- [x] Added unit test in `scripts/test-stream-sse.ts` verifying cost computation matches expected values.
- [x] Verified live non-interactive and interactive Pi turns display calculated dollar usage.

## Security

- [x] No credentials, tokens, or private account data included.
- [x] Security implications considered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accurate usage cost tracking for supported AI models.
  * Added provider-specific pricing for Gemini, Claude, GPT-OSS, and Antigravity models.
  * Streaming responses now calculate input, cached input, output, and total costs when model details are available.
* **Tests**
  * Added coverage verifying per-token pricing and calculated usage totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->