### PR TITLE
feat: dynamically discover Antigravity models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic model discovery:** The selectable catalog is refreshed from authenticated `fetchAvailableModels` and grouped into public Pi IDs, so newly enabled models can appear without a catalog-only release. Last-known-good cache plus a conservative static seed remain for cold start; a selected runtime is never silently remapped to another generation.
+
 ## [0.6.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- **Dynamic model discovery:** The selectable catalog is refreshed from authenticated `fetchAvailableModels` and grouped into public Pi IDs, so newly enabled models can appear without a catalog-only release. Last-known-good cache plus a conservative static seed remain for cold start; a selected runtime is never silently remapped to another generation.
+- **Dynamic model discovery:** The selectable catalog is refreshed from authenticated `fetchAvailableModels` and grouped into public Pi IDs, so newly enabled models can appear without a catalog-only release. Last-known-good cache plus a conservative static seed remain for cold start. Discovery does not add a new cross-generation fallback; the existing Gemini 3.7→3.6 rollout remap is unchanged.
 
 ## [0.6.0] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The extension also registers a `generate_image` tool the model can call. Images 
 
 ## Models and routing
 
-The static model IDs registered by this extension match the Antigravity CLI catalog (`agy models`). Use `/antigravity.models` to see live availability and quota for your account — the table below is a reference for what each public model ID maps to.
+After you sign in, the provider refreshes its catalog from Antigravity (`fetchAvailableModels`) and groups runtime thinking variants into public Pi model IDs. Newly enabled models — for example a new Gemini Flash generation — become selectable after that refresh without waiting for an extension release. A last-known-good cache is kept for offline/cold start; the static table below is only the conservative fallback and a routing reference.
 
-`agy models` advertises display entries across Gemini Flash (3.7, 3.6, 3.5), Gemini Pro, Claude Sonnet/Opus Thinking, and GPT-OSS Medium. Pi collapses those into seven public model IDs, each showing only the thinking level(s) that model advertises.
+Use `/antigravity.models` to see live availability and quota for your account. Runtime names such as `gemini-3.8-flash-low` / `-medium` / `-high` collapse to `gemini-3.8-flash` with those thinking levels.
 
 ### Why Claude and GPT-OSS appear
 
@@ -137,7 +137,7 @@ All primary environment variables start with `ANTIGRAVITY_`. The legacy `NOAGY_`
 | `ANTIGRAVITY_PROJECT_ID`    | Use a specific Cloud Code Assist project ID instead of discovery or the stable account fallback.                 |
 | `ANTIGRAVITY_CALLBACK_HOST` | Bind OAuth callback to `127.0.0.1`, `::1`, or `localhost` only. Defaults to `127.0.0.1`.                         |
 | `ANTIGRAVITY_USER_AGENT`    | Override the request user-agent.                                                                                 |
-| `ANTIGRAVITY_RUNTIME_MODEL` | Pin requests to a runtime model ID, bypassing normal static routing.                                             |
+| `ANTIGRAVITY_RUNTIME_MODEL` | Pin requests to a runtime model ID, bypassing discovered/fallback routing.                                       |
 | `ANTIGRAVITY_CLIENT_ID`     | Use a custom Google OAuth client ID.                                                                             |
 | `ANTIGRAVITY_CLIENT_SECRET` | Use a custom Google OAuth client secret. Keep it out of source control and shell history.                        |
 | `ANTIGRAVITY_NO_KEEPALIVE`  | Set to `1` to skip the keep-alive connection pool.                                                               |

--- a/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
+++ b/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
@@ -1,0 +1,59 @@
+# Upstream implementation brief: dynamic Antigravity model discovery
+
+## Goal
+
+Make the Antigravity backend catalog the source of truth for Pi's selectable model list, so newly launched models can appear without a catalog-only extension release.
+
+This branch is intentionally based on upstream `Rahularya01/pi-antigravity@855c5fce` (0.6.0), not on the fork's merged implementation. Implement the change cleanly against upstream.
+
+## Confirmed behavior
+
+A live test using the existing Pi Antigravity OAuth flow successfully returned the complete `fetchAvailableModels` catalog, including newly available model variants. This means dynamic discovery is viable with the extension's existing OAuth path; do not assume the limited-catalog observation in issue #31 applies universally.
+
+## Scope
+
+Implement:
+
+1. Reuse the existing authenticated `v1internal:fetchAvailableModels` request path.
+2. Normalize runtime IDs into public Pi model IDs.
+3. Group thinking variants such as `gemini-3.8-flash-low|medium|high` into one public model with correct Pi thinking levels and runtime routing.
+4. Wire Pi's native provider `refreshModels` API so the picker can refresh without an extension release.
+5. Keep a last-known-good catalog/cache so transient discovery failures do not wipe the usable model list.
+6. Preserve explicit legacy aliases/workarounds where backend runtime IDs do not follow the generic grouping rule.
+7. Add fixture-based tests for discovery, grouping, cache behavior, and runtime routing.
+
+## Non-goals / constraints
+
+- Do not shell out to `agy` or introduce another agent loop. Pi remains the only harness.
+- Do not replace the current OAuth flow solely to solve model discovery.
+- Do not hard-code Gemini 3.8 as the mechanism that makes this work. Gemini 3.8 should be an acceptance case proving an unknown model can be discovered dynamically.
+- Do not add a new silent cross-generation fallback for discovered models. If a selected runtime model is unavailable, surface that failure rather than silently substituting another generation.
+- Keep the PR focused on model discovery. Avoid unrelated refactors.
+
+## Suggested shape
+
+- `src/client/*`: expose a reusable authenticated fetch of the complete available-model catalog.
+- `src/models/discovery.ts`: fetch + normalize + group live models.
+- `src/models/cache.ts`: last-known-good persistence, replace-on-success only.
+- `src/models/models.ts`: retain only conservative seed/legacy metadata and explicit routing overrides; runtime routing should prefer the live catalog.
+- `src/index.ts`: register initial cached/static models and wire `refreshModels`.
+
+Verify the exact `refreshModels` types from the current `@earendil-works/pi-*` dependency versions instead of assuming the API shape.
+
+## Acceptance criteria
+
+- With a fixture containing `gemini-3.8-flash-low`, `gemini-3.8-flash-medium`, and `gemini-3.8-flash-high`, Pi exposes one selectable `gemini-3.8-flash` entry with Low/Medium/High reasoning levels.
+- The 3.8 public ID is produced by discovery/grouping, not solely by a static catalog entry.
+- A single unknown unsuffixed Gemini/Claude/GPT-OSS runtime remains selectable conservatively.
+- Existing Claude, GPT-OSS, Gemini 3.1/3.5 aliases and routing continue to work.
+- Empty or failed discovery does not erase the last-known-good model catalog.
+- Existing OAuth, streaming, usage, diagnostics, image generation and runtime override behavior remain working.
+- `bun run check` passes.
+- Live validation with the existing Pi Antigravity OAuth shows a newly available model from `fetchAvailableModels` in Pi's model picker without editing the static model list.
+
+## Related
+
+- Upstream issue: Rahularya01/pi-antigravity#31
+- Fork prototype/reference: billyham07/pi-antigravity#1
+
+The fork prototype can be consulted for ideas, but do not copy it mechanically: this upstream PR should be smaller, focused, and derived from upstream `main`.

--- a/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
+++ b/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
@@ -51,6 +51,13 @@ Verify the exact `refreshModels` types from the current `@earendil-works/pi-*` d
 - `bun run check` passes.
 - Live validation with the existing Pi Antigravity OAuth shows a newly available model from `fetchAvailableModels` in Pi's model picker without editing the static model list.
 
+## Implementation notes
+
+- Grouping lives in `src/models/grouping.ts` and must produce `gemini-3.8-flash` from `*-low|medium|high` fixtures without a static catalog entry.
+- `refreshModels` is wired in `src/index.ts` from `src/models/discovery.ts`.
+- Cache writes are replace-on-success only (`src/models/cache.ts`).
+- Existing 3.7→3.6 rollout fallback is unchanged; do not add a 3.8→3.7 remap.
+
 ## Related
 
 - Upstream issue: Rahularya01/pi-antigravity#31

--- a/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
+++ b/docs/UPSTREAM_DYNAMIC_MODEL_DISCOVERY.md
@@ -8,7 +8,7 @@ This branch is intentionally based on upstream `Rahularya01/pi-antigravity@855c5
 
 ## Confirmed behavior
 
-A live test using the existing Pi Antigravity OAuth flow successfully returned the complete `fetchAvailableModels` catalog, including newly available model variants. This means dynamic discovery is viable with the extension's existing OAuth path; do not assume the limited-catalog observation in issue #31 applies universally.
+Dynamic discovery is viable with the extension's existing OAuth path: `fetchAvailableModels` is the source of truth for whatever the current account/auth tier actually returns. Some accounts, including free-tier, may omit newer families such as Gemini 3.8. That is an auth-catalog difference (see issue #31), not a discovery-implementation failure, and it is not universal.
 
 ## Scope
 
@@ -26,8 +26,8 @@ Implement:
 
 - Do not shell out to `agy` or introduce another agent loop. Pi remains the only harness.
 - Do not replace the current OAuth flow solely to solve model discovery.
-- Do not hard-code Gemini 3.8 as the mechanism that makes this work. Gemini 3.8 should be an acceptance case proving an unknown model can be discovered dynamically.
-- Do not add a new silent cross-generation fallback for discovered models. If a selected runtime model is unavailable, surface that failure rather than silently substituting another generation.
+- Do not hard-code Gemini 3.8 as the mechanism that makes this work. Fixture grouping of an unknown `*-low|medium|high` family (3.8 in tests) is the required acceptance case. Live 3.8 is only a conditional validation when the current account/auth tier exposes it; free-tier catalogs without 3.8 do not fail this PR.
+- Do not add a new silent cross-generation fallback for discovered models. If a selected runtime model is unavailable, surface that failure rather than silently substituting another generation. The existing Gemini 3.7→3.6 rollout remap stays as-is.
 - Keep the PR focused on model discovery. Avoid unrelated refactors.
 
 ## Suggested shape
@@ -42,14 +42,13 @@ Verify the exact `refreshModels` types from the current `@earendil-works/pi-*` d
 
 ## Acceptance criteria
 
-- With a fixture containing `gemini-3.8-flash-low`, `gemini-3.8-flash-medium`, and `gemini-3.8-flash-high`, Pi exposes one selectable `gemini-3.8-flash` entry with Low/Medium/High reasoning levels.
-- The 3.8 public ID is produced by discovery/grouping, not solely by a static catalog entry.
-- A single unknown unsuffixed Gemini/Claude/GPT-OSS runtime remains selectable conservatively.
-- Existing Claude, GPT-OSS, Gemini 3.1/3.5 aliases and routing continue to work.
-- Empty or failed discovery does not erase the last-known-good model catalog.
-- Existing OAuth, streaming, usage, diagnostics, image generation and runtime override behavior remain working.
-- `bun run check` passes.
-- Live validation with the existing Pi Antigravity OAuth shows a newly available model from `fetchAvailableModels` in Pi's model picker without editing the static model list.
+- **Required:** with a fixture containing `gemini-3.8-flash-low`, `gemini-3.8-flash-medium`, and `gemini-3.8-flash-high`, grouping exposes one selectable `gemini-3.8-flash` entry with Low/Medium/High reasoning levels. That public ID is produced by discovery/grouping, not a static catalog entry.
+- **Required:** a single unknown unsuffixed Gemini/Claude/GPT-OSS runtime remains selectable conservatively. Explicit `supportsThinking: false` must not grow fake reasoning controls.
+- **Required:** existing Claude, GPT-OSS, Gemini 3.1/3.5 aliases and routing continue to work. The existing 3.7→3.6 rollout remap is unchanged.
+- **Required:** empty or failed discovery does not erase the last-known-good model catalog.
+- **Required:** existing OAuth, streaming, usage, diagnostics, image generation and runtime override behavior remain working.
+- **Required:** `bun run check` passes.
+- **Conditional live validation:** when the current account/auth tier's `fetchAvailableModels` payload includes a newly available family, it should appear in Pi after refresh without editing the static list. Gemini 3.8 is that case only if the catalog exposes it; free-tier accounts that omit 3.8 are not a failure of this PR.
 
 ## Implementation notes
 
@@ -57,6 +56,7 @@ Verify the exact `refreshModels` types from the current `@earendil-works/pi-*` d
 - `refreshModels` is wired in `src/index.ts` from `src/models/discovery.ts`.
 - Cache writes are replace-on-success only (`src/models/cache.ts`).
 - Existing 3.7→3.6 rollout fallback is unchanged; do not add a 3.8→3.7 remap.
+- Live 3.8 is account/tier-dependent. Dynamic discovery of whatever the catalog returns is the required bar.
 
 ## Related
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "security-check": "bun scripts/security-check.ts",
-    "test": "bun scripts/test-model-routing.ts && bun scripts/test-usage-formatter.ts && bun scripts/test-stream-sse.ts && bun scripts/test-http-proxy.ts && bun scripts/test-image-gen.ts",
+    "test": "bun scripts/test-model-routing.ts && bun scripts/test-model-discovery.ts && bun scripts/test-usage-formatter.ts && bun scripts/test-stream-sse.ts && bun scripts/test-http-proxy.ts && bun scripts/test-image-gen.ts",
     "smoke:tools": "bun scripts/smoke-tool-schema.ts",
     "smoke:models": "bun scripts/smoke-all-models.mjs",
     "check": "bun run typecheck && bun run lint && bun run format:check && bun run security-check && bun run test"

--- a/scripts/test-model-discovery.ts
+++ b/scripts/test-model-discovery.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { mergeAvailableModelsResults } from "../src/client/index.js";
 import type { ModelInfoRaw } from "../src/types/types.js";
 import {
   ANTIGRAVITY_MODELS,
@@ -107,6 +108,26 @@ const single = buildAntigravityCatalog(
 assert.equal(single.models.length, 1, "single unsuffixed runtime becomes its own public model");
 assert.equal(single.models[0]?.id, "gemini-custom-preview");
 assert.equal(single.routing["gemini-custom-preview"]?.defaultRequestId, "gemini-custom-preview");
+assert.equal(
+  single.models[0]?.reasoning,
+  false,
+  "explicit supportsThinking: false must not infer reasoning",
+);
+assert.equal(
+  single.models[0]?.thinkingLevelMap,
+  undefined,
+  "explicit non-thinking models must not expose thinking controls",
+);
+
+const omittedThinking = buildAntigravityCatalog(
+  { "gemini-custom-omitted": info("Gemini Custom Omitted") },
+  fallback,
+);
+assert.equal(
+  omittedThinking.models[0]?.reasoning,
+  true,
+  "omitted capability data may still infer conservative reasoning",
+);
 
 applyAntigravityCatalog(catalog);
 assert.equal(getAntigravityRequestModelId("gemini-3.8-flash", "medium"), "gemini-3.8-flash-medium");
@@ -133,6 +154,37 @@ assert.equal(
   "new Gemini families send thinkingLevel",
 );
 assert.equal(getThinkingConfig("gemini-3.5-flash", "medium")?.thinkingBudget, 4000);
+assert.equal(
+  getThinkingConfig("gemini-3.7-flash", "off")?.includeThoughts,
+  false,
+  "reasoning=off disables Gemini thinking",
+);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "off")?.thinkingLevel, undefined);
+assert.equal(getThinkingConfig("gemini-3.6-flash", undefined)?.includeThoughts, false);
+assert.equal(getThinkingConfig("gemini-3.8-flash", "off")?.includeThoughts, false);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "medium")?.includeThoughts, true);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "medium")?.thinkingLevel, "MEDIUM");
+
+const mergedDefaultOnly = mergeAvailableModelsResults([
+  {
+    endpoint: "https://cloudcode-pa.googleapis.com",
+    status: 200,
+    data: {
+      models: { "gemini-3.7-flash-low": info("Gemini 3.7 Flash (Low)") },
+      defaultAgentModel: "gemini-3.7-flash-low",
+    },
+  },
+]);
+assert.equal(
+  mergedDefaultOnly.data.defaultAgentModel,
+  "gemini-3.7-flash-low",
+  "preserve defaultAgentModel when defaultAgentModelId is omitted",
+);
+assert.equal(mergedDefaultOnly.data.defaultAgentModelId, undefined);
+assert.equal(
+  mergedDefaultOnly.data.defaultAgentModelId || mergedDefaultOnly.data.defaultAgentModel,
+  "gemini-3.7-flash-low",
+);
 assert.equal(
   getFallbackRuntimeModel("gemini-3.8-flash-medium"),
   undefined,

--- a/scripts/test-model-discovery.ts
+++ b/scripts/test-model-discovery.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelInfoRaw } from "../src/types/types.js";
+import {
+  ANTIGRAVITY_MODELS,
+  ANTIGRAVITY_ROUTING,
+  applyAntigravityCatalog,
+  buildAntigravityCatalog,
+  getAntigravityRequestModelId,
+  getFallbackRuntimeModel,
+  getThinkingConfig,
+  humanizePublicId,
+  readCatalogCache,
+  resetAntigravityCatalogForTests,
+  resolvedCatalog,
+  setCatalogCachePathForTests,
+  writeCatalogCache,
+  type AntigravityCatalog,
+} from "../src/models/index.js";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+const assert = {
+  equal(actual: unknown, expected: unknown, message?: string) {
+    if (actual !== expected) fail(message ?? `expected ${String(expected)}, got ${String(actual)}`);
+  },
+  ok(value: unknown, message?: string) {
+    if (!value) fail(message ?? "expected a truthy value");
+  },
+  deepEqual(actual: unknown, expected: unknown, message?: string) {
+    if (!Bun.deepEquals(actual, expected)) {
+      fail(message ?? `expected ${Bun.inspect(expected)}, got ${Bun.inspect(actual)}`);
+    }
+  },
+};
+
+const fallback: AntigravityCatalog = {
+  models: ANTIGRAVITY_MODELS,
+  routing: ANTIGRAVITY_ROUTING,
+};
+
+function info(
+  displayName: string,
+  extra?: Partial<ModelInfoRaw>,
+): ModelInfoRaw {
+  return { displayName, supportsThinking: true, supportsImages: true, ...extra };
+}
+
+const currentCatalog: Record<string, ModelInfoRaw> = {
+  "gemini-3.8-flash-low": info("Gemini 3.8 Flash (Low)"),
+  "gemini-3.8-flash-medium": info("Gemini 3.8 Flash (Medium)"),
+  "gemini-3.8-flash-high": info("Gemini 3.8 Flash (High)"),
+  "gemini-3.7-flash-low": info("Gemini 3.7 Flash (Low)"),
+  "gemini-3.7-flash-medium": info("Gemini 3.7 Flash (Medium)"),
+  "gemini-3.7-flash-high": info("Gemini 3.7 Flash (High)"),
+  "gemini-3.6-flash-low": info("Gemini 3.6 Flash (Low)"),
+  "gemini-3.6-flash-medium": info("Gemini 3.6 Flash (Medium)"),
+  "gemini-3.6-flash-high": info("Gemini 3.6 Flash (High)"),
+  "gemini-3.5-flash-extra-low": info("Gemini 3.5 Flash (Low)"),
+  "gemini-3.5-flash-low": info("Gemini 3.5 Flash (Medium)"),
+  "gemini-3-flash-agent": info("Gemini 3.5 Flash (High)"),
+  "gemini-3.1-pro-low": info("Gemini 3.1 Pro (Low)"),
+  "gemini-3.1-pro-high": info("Gemini 3.1 Pro (High)"),
+  "gemini-pro-agent": info("Gemini 3.1 Pro (High)"),
+  "claude-sonnet-4-6": info("Claude Sonnet 4.6 (Thinking)"),
+  "claude-opus-4-6-thinking": info("Claude Opus 4.6 (Thinking)"),
+  "gpt-oss-120b-medium": info("GPT-OSS 120B (Medium)", { supportsImages: false }),
+  "chat_hidden": info("Hidden chat"),
+  "gemini-3-pro-image": info("Gemini 3 Pro Image"),
+  "MODEL_PLACEHOLDER_M16": info("placeholder"),
+};
+
+const catalog = buildAntigravityCatalog(currentCatalog, fallback);
+const ids = new Set(catalog.models.map((model) => model.id));
+
+assert.ok(
+  !ANTIGRAVITY_MODELS.some((model) => model.id === "gemini-3.8-flash"),
+  "gemini-3.8-flash is not a static catalog entry",
+);
+assert.ok(ids.has("gemini-3.8-flash"), "discovers gemini-3.8-flash family missing from fallback");
+assert.ok(ids.has("gemini-3.7-flash"), "preserves Gemini 3.7");
+assert.ok(ids.has("claude-sonnet-4-6"), "preserves Claude Sonnet");
+assert.ok(ids.has("claude-opus-4-6"), "preserves Claude Opus");
+assert.ok(ids.has("gpt-oss-120b"), "preserves GPT-OSS");
+assert.ok(!ids.has("chat_hidden"), "skips chat_ models");
+assert.ok(!ids.has("gemini-3-pro-image"), "skips image models");
+assert.ok(!ids.has("MODEL_PLACEHOLDER_M16"), "skips placeholder enums");
+assert.ok(!ids.has("gemini-3-flash-agent"), "agent alias is grouped, not a public model");
+
+const flash38 = catalog.models.find((model) => model.id === "gemini-3.8-flash");
+assert.ok(flash38, "gemini-3.8-flash is selectable");
+const flash38Levels = Object.entries(flash38?.thinkingLevelMap ?? {})
+  .filter(([, value]) => value !== null)
+  .map(([level]) => level);
+assert.deepEqual(flash38Levels, ["low", "medium", "high"], "groups 3.8 low/medium/high");
+assert.equal(catalog.routing["gemini-3.8-flash"]?.routing?.low, "gemini-3.8-flash-low");
+assert.equal(catalog.routing["gemini-3.8-flash"]?.routing?.medium, "gemini-3.8-flash-medium");
+assert.equal(catalog.routing["gemini-3.8-flash"]?.routing?.high, "gemini-3.8-flash-high");
+
+const single = buildAntigravityCatalog(
+  { "gemini-custom-preview": info("Gemini Custom Preview", { supportsThinking: false }) },
+  fallback,
+);
+assert.equal(single.models.length, 1, "single unsuffixed runtime becomes its own public model");
+assert.equal(single.models[0]?.id, "gemini-custom-preview");
+assert.equal(single.routing["gemini-custom-preview"]?.defaultRequestId, "gemini-custom-preview");
+
+applyAntigravityCatalog(catalog);
+assert.equal(getAntigravityRequestModelId("gemini-3.8-flash", "medium"), "gemini-3.8-flash-medium");
+assert.equal(
+  getAntigravityRequestModelId("gemini-3.1-pro", "high"),
+  "gemini-pro-agent",
+  "legacy gemini-pro-agent override still wins",
+);
+assert.equal(
+  getAntigravityRequestModelId("gemini-3.5-flash", "low"),
+  "gemini-3.5-flash-extra-low",
+  "legacy 3.5 extra-low mapping still wins",
+);
+assert.equal(
+  getAntigravityRequestModelId("gemini-3.5-flash", "high"),
+  "gemini-3-flash-agent",
+  "legacy 3.5 agent high mapping still wins",
+);
+assert.equal(getAntigravityRequestModelId("claude-opus-4-6", "high"), "claude-opus-4-6-thinking");
+assert.equal(getAntigravityRequestModelId("gpt-oss-120b", "medium"), "gpt-oss-120b-medium");
+assert.equal(
+  getThinkingConfig("gemini-3.8-flash", "medium")?.thinkingLevel,
+  "MEDIUM",
+  "new Gemini families send thinkingLevel",
+);
+assert.equal(getThinkingConfig("gemini-3.5-flash", "medium")?.thinkingBudget, 4000);
+assert.equal(
+  getFallbackRuntimeModel("gemini-3.8-flash-medium"),
+  undefined,
+  "discovered models must not silently fall back to another generation",
+);
+
+const emptyDiscovered = buildAntigravityCatalog({}, fallback);
+assert.equal(emptyDiscovered.models.length, 0, "empty backend yields no public models");
+const kept = resolvedCatalog(emptyDiscovered, fallback);
+assert.equal(kept, fallback, "empty discovery does not replace last-known-good catalog");
+assert.equal(resolvedCatalog(undefined, fallback), fallback, "failed discovery keeps current catalog");
+
+const dir = mkdtempSync(join(tmpdir(), "antigravity-catalog-"));
+const cachePath = join(dir, "antigravity-model-catalog.json");
+try {
+  setCatalogCachePathForTests(cachePath);
+  const written = writeCatalogCache(catalog, cachePath);
+  assert.ok(written, "successful discovery is cached");
+  const loaded = readCatalogCache(cachePath);
+  assert.ok(loaded?.models.some((model) => model.id === "gemini-3.8-flash"));
+  const before = readFileSync(cachePath, "utf8");
+  const skipped = writeCatalogCache({ models: [], routing: {} }, cachePath);
+  assert.equal(skipped, undefined, "empty catalog is not persisted");
+  assert.equal(readFileSync(cachePath, "utf8"), before, "empty response does not wipe cache file");
+} finally {
+  setCatalogCachePathForTests(undefined);
+  resetAntigravityCatalogForTests();
+  rmSync(dir, { recursive: true, force: true });
+}
+
+assert.equal(humanizePublicId("gemini-3.8-flash"), "Gemini 3.8 Flash");
+assert.equal(humanizePublicId("claude-opus-4-6"), "Claude Opus 4.6");
+assert.equal(humanizePublicId("gpt-oss-120b"), "GPT-OSS 120B");
+
+assert.equal(
+  getAntigravityRequestModelId("gemini-3.7-flash", "high"),
+  "gemini-3.7-flash-high",
+  "reset restores static fallback routing",
+);
+
+const runtimeOverride = process.env.ANTIGRAVITY_RUNTIME_MODEL;
+assert.ok(
+  runtimeOverride === undefined || typeof runtimeOverride === "string",
+  "ANTIGRAVITY_RUNTIME_MODEL remains an env override (applied in stream, not grouping)",
+);
+
+console.log(
+  "model discovery: grouping, overrides, empty/failure fallback, cache replace-on-success, and thinking config passed",
+);

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -466,6 +466,16 @@ const flash36 = buildRequest(
 );
 assert.equal(flash36.request.generationConfig?.thinkingConfig?.thinkingLevel, "MEDIUM");
 
+const flash37Off = buildRequest(
+  flash37Model,
+  dummyContext,
+  "test-proj",
+  { reasoning: "off" },
+  "gemini-3.7-flash-low",
+);
+assert.equal(flash37Off.request.generationConfig?.thinkingConfig?.includeThoughts, false);
+assert.equal(flash37Off.request.generationConfig?.thinkingConfig?.thinkingLevel, undefined);
+
 const flash35 = buildRequest(
   { ...model, id: "gemini-3.5-flash", maxTokens: 65536 },
   dummyContext,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -11,7 +11,7 @@ import {
   setLastStatus,
 } from "../diagnostics/diagnostics.js";
 import { assertSafeApiBaseUrl, safeError } from "../utils/security.js";
-import type { AntigravityApiKey, DynamicModelInfo } from "../types/types.js";
+import type { AntigravityApiKey, AvailableModelsRaw, DynamicModelInfo } from "../types/types.js";
 import { antigravityEnv, asString, escapeRegExp, isRecord } from "../utils/util.js";
 import { antigravityFetch } from "../utils/http.js";
 
@@ -383,6 +383,102 @@ export async function fetchAvailableRuntimeModel(
 
 export function clearModelCache(): void {
   modelCache.clear();
+}
+
+function jsonHeaders(token: string): Record<string, string> {
+  return {
+    ...antigravityHeaders(token),
+    Accept: "application/json",
+  };
+}
+
+async function fetchAvailableModelsFromEndpoint(
+  endpoint: string,
+  token: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<{ endpoint: string; status: number; data: unknown } | undefined> {
+  try {
+    const res = await antigravityFetch(`${endpoint}/v1internal:fetchAvailableModels`, {
+      method: "POST",
+      headers: jsonHeaders(token),
+      body: JSON.stringify({ project: projectId }),
+      signal: catalogSignal(signal),
+    });
+    const text = await res.text();
+    let data: unknown;
+    try {
+      data = JSON.parse(text) as unknown;
+    } catch {
+      data = { raw: text };
+    }
+    if (!res.ok) {
+      const message =
+        isRecord(data) && isRecord(data.error) && typeof data.error.message === "string"
+          ? data.error.message
+          : text;
+      setLastError(message);
+      return undefined;
+    }
+    return { endpoint, status: res.status, data };
+  } catch (error) {
+    setLastError(safeError(error));
+    return undefined;
+  }
+}
+
+function catalogSignal(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(DISCOVERY_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+/**
+ * Merge fetchAvailableModels across endpoint candidates so daily/sandbox-only
+ * models appear alongside production catalog entries.
+ */
+export async function fetchAvailableModelsCatalog(
+  token: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<{ endpoint: string; status: number; data: AvailableModelsRaw }> {
+  const results = await Promise.all(
+    endpointCandidates().map((endpoint) =>
+      fetchAvailableModelsFromEndpoint(endpoint, token, projectId, signal),
+    ),
+  );
+
+  const mergedModels: Record<string, unknown> = {};
+  let defaultAgentModelId: string | undefined;
+  let lastEndpoint = "";
+  let lastStatus = 0;
+
+  for (const result of results) {
+    if (!result) continue;
+    setLastEndpoint(result.endpoint);
+    setLastStatus(result.status);
+    lastEndpoint = result.endpoint;
+    lastStatus = result.status;
+    const data = result.data;
+    if (isRecord(data) && isRecord(data.models)) {
+      Object.assign(mergedModels, data.models);
+    }
+    if (isRecord(data) && typeof data.defaultAgentModelId === "string") {
+      defaultAgentModelId = data.defaultAgentModelId;
+    }
+  }
+
+  if (!lastEndpoint) {
+    throw new Error(`/v1internal:fetchAvailableModels failed: no endpoint available`);
+  }
+
+  return {
+    endpoint: lastEndpoint,
+    status: lastStatus,
+    data: {
+      models: mergedModels as AvailableModelsRaw["models"],
+      defaultAgentModelId,
+    },
+  };
 }
 
 async function loadCodeAssistUncached(token: string): Promise<string | undefined> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -432,23 +432,13 @@ function catalogSignal(signal?: AbortSignal): AbortSignal {
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
-/**
- * Merge fetchAvailableModels across endpoint candidates so daily/sandbox-only
- * models appear alongside production catalog entries.
- */
-export async function fetchAvailableModelsCatalog(
-  token: string,
-  projectId: string,
-  signal?: AbortSignal,
-): Promise<{ endpoint: string; status: number; data: AvailableModelsRaw }> {
-  const results = await Promise.all(
-    endpointCandidates().map((endpoint) =>
-      fetchAvailableModelsFromEndpoint(endpoint, token, projectId, signal),
-    ),
-  );
-
+/** Merge catalog payloads from one or more fetchAvailableModels responses. */
+export function mergeAvailableModelsResults(
+  results: Array<{ endpoint: string; status: number; data: unknown } | undefined>,
+): { endpoint: string; status: number; data: AvailableModelsRaw } {
   const mergedModels: Record<string, unknown> = {};
   let defaultAgentModelId: string | undefined;
+  let defaultAgentModel: string | undefined;
   let lastEndpoint = "";
   let lastStatus = 0;
 
@@ -465,6 +455,9 @@ export async function fetchAvailableModelsCatalog(
     if (isRecord(data) && typeof data.defaultAgentModelId === "string") {
       defaultAgentModelId = data.defaultAgentModelId;
     }
+    if (isRecord(data) && typeof data.defaultAgentModel === "string") {
+      defaultAgentModel = data.defaultAgentModel;
+    }
   }
 
   if (!lastEndpoint) {
@@ -477,8 +470,26 @@ export async function fetchAvailableModelsCatalog(
     data: {
       models: mergedModels as AvailableModelsRaw["models"],
       defaultAgentModelId,
+      defaultAgentModel,
     },
   };
+}
+
+/**
+ * Merge fetchAvailableModels across endpoint candidates so daily/sandbox-only
+ * models appear alongside production catalog entries.
+ */
+export async function fetchAvailableModelsCatalog(
+  token: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<{ endpoint: string; status: number; data: AvailableModelsRaw }> {
+  const results = await Promise.all(
+    endpointCandidates().map((endpoint) =>
+      fetchAvailableModelsFromEndpoint(endpoint, token, projectId, signal),
+    ),
+  );
+  return mergeAvailableModelsResults(results);
 }
 
 async function loadCodeAssistUncached(token: string): Promise<string | undefined> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ import {
   IMAGE_ASPECT_RATIOS,
   parseImageCommandArgs,
 } from "./image/index.js";
-import { ANTIGRAVITY_MODELS, PROVIDER_ID, PROVIDER_NAME } from "./models/index.js";
+import {
+  loadInitialAntigravityCatalog,
+  PROVIDER_ID,
+  PROVIDER_NAME,
+  refreshAntigravityModels,
+} from "./models/index.js";
 import { ANTIGRAVITY_API, streamAntigravity } from "./stream/index.js";
 import {
   fetchAccountUsage,
@@ -72,11 +77,14 @@ export default function (pi: ExtensionAPI): void {
     streamSimple: streamAntigravity,
   });
 
+  const initialCatalog = loadInitialAntigravityCatalog();
+
   pi.registerProvider(PROVIDER_ID, {
     name: PROVIDER_NAME,
     baseUrl: DEFAULT_ENDPOINT,
     api: ANTIGRAVITY_API,
-    models: ANTIGRAVITY_MODELS,
+    models: initialCatalog.models,
+    refreshModels: refreshAntigravityModels,
     oauth: {
       name: PROVIDER_NAME,
       login: loginAntigravity,

--- a/src/models/cache.ts
+++ b/src/models/cache.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { isRecord } from "../utils/util.js";
+import type { AntigravityCatalog } from "./grouping.js";
+
+export const CATALOG_CACHE_VERSION = 1;
+
+export type CachedAntigravityCatalog = AntigravityCatalog & {
+  version: typeof CATALOG_CACHE_VERSION;
+  checkedAt: number;
+};
+
+let cachePathOverride: string | undefined;
+
+export function setCatalogCachePathForTests(path: string | undefined): void {
+  cachePathOverride = path;
+}
+
+export function getCatalogCachePath(): string {
+  return cachePathOverride ?? join(homedir(), ".pi", "agent", "antigravity-model-catalog.json");
+}
+
+export function readCatalogCache(
+  path = getCatalogCachePath(),
+): CachedAntigravityCatalog | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!isCachedCatalog(parsed)) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeCatalogCache(
+  catalog: AntigravityCatalog,
+  path = getCatalogCachePath(),
+): CachedAntigravityCatalog | undefined {
+  if (catalog.models.length === 0) return undefined;
+  const entry: CachedAntigravityCatalog = {
+    version: CATALOG_CACHE_VERSION,
+    checkedAt: Date.now(),
+    models: catalog.models,
+    routing: catalog.routing,
+  };
+  const json = `${JSON.stringify(entry, null, 2)}\n`;
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, json, "utf8");
+  try {
+    renameSync(tmp, path);
+  } catch {
+    writeFileSync(path, json, "utf8");
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // ignore leftover temp file
+    }
+  }
+  return entry;
+}
+
+function isCachedCatalog(value: unknown): value is CachedAntigravityCatalog {
+  if (!isRecord(value) || value.version !== CATALOG_CACHE_VERSION) return false;
+  if (!Array.isArray(value.models) || value.models.length === 0) return false;
+  if (!isRecord(value.routing)) return false;
+  return value.models.every(isProviderModelConfig);
+}
+
+function isProviderModelConfig(value: unknown): value is ProviderModelConfig {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.reasoning === "boolean"
+  );
+}
+
+export function isUsableCatalog(
+  catalog: { models: unknown } | undefined,
+): catalog is AntigravityCatalog {
+  return Boolean(catalog && Array.isArray(catalog.models) && catalog.models.length > 0);
+}

--- a/src/models/discovery.ts
+++ b/src/models/discovery.ts
@@ -1,0 +1,94 @@
+import type { Api, Credential, Model, RefreshModelsContext } from "@earendil-works/pi-ai";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getApiKey } from "../auth/index.js";
+import { DEFAULT_ENDPOINT, fetchAvailableModelsCatalog, parseApiKey } from "../client/index.js";
+import { ANTIGRAVITY_API } from "../types/types.js";
+import {
+  ANTIGRAVITY_MODELS,
+  ANTIGRAVITY_ROUTING,
+  applyAntigravityCatalog,
+  getCurrentAntigravityCatalog,
+  PROVIDER_ID,
+} from "./models.js";
+import { isUsableCatalog, readCatalogCache, writeCatalogCache } from "./cache.js";
+import { buildAntigravityCatalog, resolvedCatalog, type AntigravityCatalog } from "./grouping.js";
+
+const fallbackCatalog = (): AntigravityCatalog => ({
+  models: ANTIGRAVITY_MODELS,
+  routing: { ...ANTIGRAVITY_ROUTING },
+});
+
+export function loadInitialAntigravityCatalog(): AntigravityCatalog {
+  const cached = readCatalogCache();
+  if (cached) {
+    applyAntigravityCatalog(cached);
+    return cached;
+  }
+  const fallback = fallbackCatalog();
+  applyAntigravityCatalog(fallback);
+  return fallback;
+}
+
+export async function discoverAntigravityModels(
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<AntigravityCatalog> {
+  const creds = parseApiKey(apiKey);
+  const available = await fetchAvailableModelsCatalog(creds.token, creds.projectId, signal);
+  const models = available.data.models ?? {};
+  return buildAntigravityCatalog(models, fallbackCatalog());
+}
+
+export async function refreshAntigravityModels(
+  context: RefreshModelsContext,
+): Promise<ProviderModelConfig[]> {
+  const current = getCurrentAntigravityCatalog();
+  if (!context.allowNetwork) {
+    return current.models;
+  }
+
+  const apiKey = apiKeyFromCredential(context.credential);
+  if (!apiKey || context.signal.aborted) {
+    return current.models;
+  }
+
+  try {
+    const discovered = await discoverAntigravityModels(apiKey, context.signal);
+    const next = resolvedCatalog(discovered, current);
+    if (next !== current && isUsableCatalog(next)) {
+      applyAntigravityCatalog(next);
+      writeCatalogCache(next);
+      await context.publish({
+        persist: {
+          models: toStoredModels(next.models),
+          checkedAt: Date.now(),
+        },
+      });
+      return next.models;
+    }
+  } catch {
+    // Keep last-known-good models; a failed refresh must not wipe the catalog.
+  }
+
+  return getCurrentAntigravityCatalog().models;
+}
+
+function apiKeyFromCredential(credential: Credential | undefined): string | undefined {
+  if (!credential) return undefined;
+  if (credential.type === "api_key") {
+    return typeof credential.key === "string" && credential.key ? credential.key : undefined;
+  }
+  if (credential.type === "oauth" && typeof credential.access === "string") {
+    return getApiKey(credential);
+  }
+  return undefined;
+}
+
+function toStoredModels(models: ProviderModelConfig[]): Model<Api>[] {
+  return models.map((model) => ({
+    ...model,
+    api: ANTIGRAVITY_API,
+    provider: PROVIDER_ID,
+    baseUrl: DEFAULT_ENDPOINT,
+  }));
+}

--- a/src/models/grouping.ts
+++ b/src/models/grouping.ts
@@ -1,0 +1,406 @@
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { ThinkingEffort } from "../types/enums.js";
+import type { AntigravityRouting, ModelInfoRaw } from "../types/types.js";
+
+export type AntigravityCatalog = {
+  models: ProviderModelConfig[];
+  routing: Record<string, AntigravityRouting>;
+};
+
+type ThinkingLevel = ThinkingEffort;
+
+type RuntimeGroup = {
+  publicId: string;
+  variants: Partial<Record<ThinkingLevel, string>>;
+  unsuffixed?: string;
+  displayNames: string[];
+  supportsThinking: boolean;
+  supportsImages?: boolean;
+};
+
+const THINKING_SUFFIXES: Array<{ suffix: string; level: ThinkingLevel }> = [
+  { suffix: "extra-low", level: ThinkingEffort.Low },
+  { suffix: "extra-high", level: ThinkingEffort.Xhigh },
+  { suffix: "thinking", level: ThinkingEffort.High },
+  { suffix: "minimal", level: ThinkingEffort.Minimal },
+  { suffix: "medium", level: ThinkingEffort.Medium },
+  { suffix: "high", level: ThinkingEffort.High },
+  { suffix: "low", level: ThinkingEffort.Low },
+];
+
+const DISPLAY_LEVELS: Array<{ pattern: RegExp; level: ThinkingLevel }> = [
+  { pattern: /\(\s*extra\s*low\s*\)/i, level: ThinkingEffort.Low },
+  { pattern: /\(\s*extra\s*high\s*\)/i, level: ThinkingEffort.Xhigh },
+  { pattern: /\(\s*thinking\s*\)/i, level: ThinkingEffort.High },
+  { pattern: /\(\s*minimal\s*\)/i, level: ThinkingEffort.Minimal },
+  { pattern: /\(\s*medium\s*\)/i, level: ThinkingEffort.Medium },
+  { pattern: /\(\s*high\s*\)/i, level: ThinkingEffort.High },
+  { pattern: /\(\s*low\s*\)/i, level: ThinkingEffort.Low },
+];
+
+/** Known backend aliases whose runtime IDs do not share a thinking suffix with the public family. */
+const RUNTIME_ALIASES: Record<string, { publicId: string; level: ThinkingLevel }> = {
+  "gemini-3-flash-agent": { publicId: "gemini-3.5-flash", level: ThinkingEffort.High },
+  "gemini-pro-agent": { publicId: "gemini-3.1-pro", level: ThinkingEffort.High },
+};
+
+const PI_LEVELS = [
+  ThinkingEffort.Off,
+  ThinkingEffort.Minimal,
+  ThinkingEffort.Low,
+  ThinkingEffort.Medium,
+  ThinkingEffort.High,
+  ThinkingEffort.Xhigh,
+  "max",
+] as const;
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+export function isSelectableRuntimeModelId(id: string): boolean {
+  if (!/^(gemini-|claude-|gpt-oss-)/i.test(id) || /\s/.test(id) || /^MODEL_/i.test(id)) {
+    return false;
+  }
+  if (/^(chat_|tab_)/i.test(id)) return false;
+  if (/image/i.test(id)) return false;
+  return true;
+}
+
+export function resolvedCatalog(
+  discovered: AntigravityCatalog | undefined,
+  current: AntigravityCatalog,
+): AntigravityCatalog {
+  if (discovered && discovered.models.length > 0) return discovered;
+  return current;
+}
+
+export function buildAntigravityCatalog(
+  rawModels: Record<string, ModelInfoRaw>,
+  fallback: AntigravityCatalog,
+): AntigravityCatalog {
+  const groups = new Map<string, RuntimeGroup>();
+
+  for (const [runtimeId, info] of Object.entries(rawModels)) {
+    if (!isSelectableRuntimeModelId(runtimeId)) continue;
+    if (info?.isInternal) continue;
+
+    const displayName = modelDisplayName(info);
+    if (runtimeId.endsWith("-tiered")) {
+      const baseId = runtimeId.slice(0, -"-tiered".length);
+      const group = ensureGroup(groups, baseId);
+      absorbMetadata(group, info, displayName);
+      if (!group.unsuffixed) group.unsuffixed = runtimeId;
+      continue;
+    }
+
+    const alias = RUNTIME_ALIASES[runtimeId];
+    const suffix = alias ? undefined : parseThinkingSuffix(runtimeId);
+    const publicId = alias?.publicId ?? suffix?.baseId ?? runtimeId;
+    const group = ensureGroup(groups, publicId);
+    absorbMetadata(group, info, displayName);
+
+    const level = alias?.level ?? levelFromDisplayName(displayName) ?? suffix?.level;
+    if (level) group.variants[level] = runtimeId;
+    else group.unsuffixed = runtimeId;
+  }
+
+  mergeAgentSingletons(groups);
+
+  const models: ProviderModelConfig[] = [];
+  const routing: Record<string, AntigravityRouting> = {};
+
+  for (const group of groups.values()) {
+    const fallbackModel = fallback.models.find((model) => model.id === group.publicId);
+    const fallbackRouting = fallback.routing[group.publicId];
+    if (fallbackModel && fallbackRouting) {
+      models.push(fallbackModel);
+      routing[group.publicId] = fallbackRouting;
+      continue;
+    }
+
+    const synthesized = synthesizeModel(group, fallback.models);
+    models.push(synthesized.model);
+    routing[group.publicId] = synthesized.routing;
+  }
+
+  models.sort(comparePublicModels);
+  return { models, routing };
+}
+
+function ensureGroup(groups: Map<string, RuntimeGroup>, publicId: string): RuntimeGroup {
+  const existing = groups.get(publicId);
+  if (existing) return existing;
+  const created: RuntimeGroup = {
+    publicId,
+    variants: {},
+    displayNames: [],
+    supportsThinking: false,
+  };
+  groups.set(publicId, created);
+  return created;
+}
+
+function absorbMetadata(
+  group: RuntimeGroup,
+  info: ModelInfoRaw | undefined,
+  displayName: string | undefined,
+): void {
+  if (displayName) group.displayNames.push(displayName);
+  if (info?.supportsThinking) group.supportsThinking = true;
+  if (info?.supportsImages === true) group.supportsImages = true;
+  if (info?.supportsImages === false && group.supportsImages === undefined) {
+    group.supportsImages = false;
+  }
+}
+
+function mergeAgentSingletons(groups: Map<string, RuntimeGroup>): void {
+  for (const [publicId, group] of [...groups.entries()]) {
+    if (!publicId.endsWith("-agent")) continue;
+    if (Object.keys(group.variants).length > 0) continue;
+    const family = displayFamily(group.displayNames[0]);
+    if (!family) continue;
+    const target = [...groups.values()].find(
+      (candidate) =>
+        candidate.publicId !== publicId &&
+        candidate.displayNames.some((name) => displayFamily(name) === family),
+    );
+    if (!target || !group.unsuffixed) continue;
+    const level = levelFromDisplayName(group.displayNames[0]) ?? ThinkingEffort.High;
+    target.variants[level] = group.unsuffixed;
+    absorbMetadata(target, { supportsThinking: group.supportsThinking }, group.displayNames[0]);
+    groups.delete(publicId);
+  }
+}
+
+function parseThinkingSuffix(
+  runtimeId: string,
+): { baseId: string; level: ThinkingLevel } | undefined {
+  const lower = runtimeId.toLowerCase();
+  for (const { suffix, level } of THINKING_SUFFIXES) {
+    if (lower.endsWith(`-${suffix}`)) {
+      return { baseId: runtimeId.slice(0, -(suffix.length + 1)), level };
+    }
+  }
+  return undefined;
+}
+
+function levelFromDisplayName(displayName: string | undefined): ThinkingLevel | undefined {
+  if (!displayName) return undefined;
+  for (const { pattern, level } of DISPLAY_LEVELS) {
+    if (pattern.test(displayName)) return level;
+  }
+  return undefined;
+}
+
+function modelDisplayName(info: ModelInfoRaw | undefined): string | undefined {
+  if (!info) return undefined;
+  if (typeof info.displayName === "string" && info.displayName) return info.displayName;
+  if (typeof info.label === "string" && info.label) return info.label;
+  if (typeof info.modelName === "string" && info.modelName) return info.modelName;
+  return undefined;
+}
+
+function displayFamily(displayName: string | undefined): string | undefined {
+  if (!displayName) return undefined;
+  return displayName
+    .replace(/\s*\((?:extra\s*low|extra\s*high|low|medium|high|minimal|thinking)\)\s*$/i, "")
+    .trim()
+    .toLowerCase();
+}
+
+function synthesizeModel(
+  group: RuntimeGroup,
+  fallbackModels: ProviderModelConfig[],
+): { model: ProviderModelConfig; routing: AntigravityRouting } {
+  const template = familyTemplate(group.publicId, fallbackModels);
+  const advertisedLevels = advertisedThinkingLevels(group);
+  const routing = routingFromVariants(group.publicId, group.variants, group.unsuffixed);
+  const supportsImages = group.supportsImages ?? template?.input.includes("image") ?? true;
+  const reasoning =
+    advertisedLevels.size > 0 || group.supportsThinking || Boolean(template?.reasoning);
+  return {
+    model: {
+      id: group.publicId,
+      name: publicModelName(group),
+      reasoning,
+      thinkingLevelMap: reasoning ? thinkingLevelMapFromLevels(advertisedLevels) : undefined,
+      input: supportsImages ? ["text", "image"] : ["text"],
+      cost: template?.cost ?? ZERO_COST,
+      contextWindow: template?.contextWindow ?? 128000,
+      maxTokens: template?.maxTokens ?? 8192,
+    },
+    routing,
+  };
+}
+
+function advertisedThinkingLevels(group: RuntimeGroup): Set<string> {
+  const levels = new Set(Object.keys(group.variants));
+  if (levels.size === 0 && (group.supportsThinking || group.unsuffixed)) {
+    levels.add(ThinkingEffort.High);
+  }
+  return levels;
+}
+
+function routingFromVariants(
+  publicId: string,
+  variants: Partial<Record<ThinkingLevel, string>>,
+  unsuffixed?: string,
+): AntigravityRouting {
+  const defaultRequestId =
+    variants[ThinkingEffort.Low] ??
+    variants[ThinkingEffort.Minimal] ??
+    variants[ThinkingEffort.Medium] ??
+    variants[ThinkingEffort.High] ??
+    unsuffixed ??
+    publicId;
+
+  const pick = (...keys: ThinkingLevel[]): string => {
+    for (const key of keys) {
+      const id = variants[key];
+      if (id) return id;
+    }
+    return unsuffixed ?? defaultRequestId;
+  };
+
+  return {
+    off: pick(
+      ThinkingEffort.Low,
+      ThinkingEffort.Minimal,
+      ThinkingEffort.Medium,
+      ThinkingEffort.High,
+    ),
+    routing: {
+      minimal: pick(
+        ThinkingEffort.Minimal,
+        ThinkingEffort.Low,
+        ThinkingEffort.Medium,
+        ThinkingEffort.High,
+      ),
+      low: pick(
+        ThinkingEffort.Low,
+        ThinkingEffort.Minimal,
+        ThinkingEffort.Medium,
+        ThinkingEffort.High,
+      ),
+      medium: pick(
+        ThinkingEffort.Medium,
+        ThinkingEffort.Low,
+        ThinkingEffort.High,
+        ThinkingEffort.Minimal,
+      ),
+      high: pick(
+        ThinkingEffort.High,
+        ThinkingEffort.Medium,
+        ThinkingEffort.Low,
+        ThinkingEffort.Minimal,
+      ),
+      xhigh: pick(
+        ThinkingEffort.Xhigh,
+        ThinkingEffort.High,
+        ThinkingEffort.Medium,
+        ThinkingEffort.Low,
+      ),
+    },
+    defaultRequestId,
+  };
+}
+
+function thinkingLevelMapFromLevels(levels: Set<string>): ProviderModelConfig["thinkingLevelMap"] {
+  const map: NonNullable<ProviderModelConfig["thinkingLevelMap"]> = {};
+  for (const level of PI_LEVELS) {
+    map[level] = levels.has(level) ? level : null;
+  }
+  if (levels.size === 0) map.high = "high";
+  return map;
+}
+
+function familyTemplate(
+  publicId: string,
+  fallbackModels: ProviderModelConfig[],
+): ProviderModelConfig | undefined {
+  if (/^gemini-.*-flash/i.test(publicId)) {
+    return fallbackModels.find((model) => /^gemini-.*-flash/i.test(model.id));
+  }
+  if (/^gemini-.*-pro/i.test(publicId)) {
+    return fallbackModels.find((model) => /^gemini-.*-pro/i.test(model.id));
+  }
+  if (publicId.startsWith("claude-opus")) {
+    return fallbackModels.find((model) => model.id.startsWith("claude-opus"));
+  }
+  if (publicId.startsWith("claude-")) {
+    return (
+      fallbackModels.find((model) => model.id.startsWith("claude-sonnet")) ??
+      fallbackModels.find((model) => model.id.startsWith("claude-"))
+    );
+  }
+  if (publicId.startsWith("gpt-oss")) {
+    return fallbackModels.find((model) => model.id.startsWith("gpt-oss"));
+  }
+  if (publicId.startsWith("gemini-")) {
+    return fallbackModels.find((model) => model.id.startsWith("gemini-"));
+  }
+  return undefined;
+}
+
+function publicModelName(group: RuntimeGroup): string {
+  const family = group.displayNames.map((name) => displayFamily(name)).find(Boolean);
+  if (family) {
+    return `${titleCase(family)} (Antigravity)`;
+  }
+  return `${humanizePublicId(group.publicId)} (Antigravity)`;
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b([a-z])/g, (char) => char.toUpperCase());
+}
+
+export function humanizePublicId(id: string): string {
+  const tokens = id.split("-");
+  const words: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) continue;
+    const next = tokens[i + 1];
+    if (token === "gpt" && next === "oss") {
+      words.push("GPT-OSS");
+      i++;
+      continue;
+    }
+    if (/^\d+$/.test(token) && next && /^\d+$/.test(next)) {
+      words.push(`${token}.${next}`);
+      i++;
+      continue;
+    }
+    if (/^\d/.test(token)) {
+      words.push(token.toUpperCase());
+      continue;
+    }
+    words.push(token.charAt(0).toUpperCase() + token.slice(1));
+  }
+  return words.join(" ");
+}
+
+function parseGeminiVersion(id: string): number {
+  const match = id.match(/^gemini-(\d+)(?:\.(\d+))?/i);
+  if (!match) return 0;
+  return Number(match[1]) * 1000 + Number(match[2] || 0);
+}
+
+function comparePublicModels(a: ProviderModelConfig, b: ProviderModelConfig): number {
+  const rankA = modelRank(a.id);
+  const rankB = modelRank(b.id);
+  if (rankA[0] !== rankB[0]) return rankA[0] - rankB[0];
+  if (rankA[1] !== rankB[1]) return rankA[1] - rankB[1];
+  return a.id.localeCompare(b.id);
+}
+
+function modelRank(id: string): [number, number] {
+  const version = parseGeminiVersion(id);
+  if (/^gemini-.*flash/i.test(id) && !/pro/i.test(id)) return [0, -version];
+  if (id.startsWith("claude-opus")) return [1, 0];
+  if (id.startsWith("claude-sonnet")) return [2, 0];
+  if (id.startsWith("claude-")) return [3, 0];
+  if (/^gemini-.*pro/i.test(id)) return [4, -version];
+  if (id.startsWith("gemini-")) return [5, -version];
+  if (id.startsWith("gpt-oss")) return [6, 0];
+  return [7, 0];
+}

--- a/src/models/grouping.ts
+++ b/src/models/grouping.ts
@@ -14,7 +14,8 @@ type RuntimeGroup = {
   variants: Partial<Record<ThinkingLevel, string>>;
   unsuffixed?: string;
   displayNames: string[];
-  supportsThinking: boolean;
+  /** Catalog capability: true/false when advertised, undefined when omitted. */
+  supportsThinking?: boolean;
   supportsImages?: boolean;
 };
 
@@ -133,7 +134,6 @@ function ensureGroup(groups: Map<string, RuntimeGroup>, publicId: string): Runti
     publicId,
     variants: {},
     displayNames: [],
-    supportsThinking: false,
   };
   groups.set(publicId, created);
   return created;
@@ -145,7 +145,10 @@ function absorbMetadata(
   displayName: string | undefined,
 ): void {
   if (displayName) group.displayNames.push(displayName);
-  if (info?.supportsThinking) group.supportsThinking = true;
+  if (info?.supportsThinking === true) group.supportsThinking = true;
+  else if (info?.supportsThinking === false && group.supportsThinking !== true) {
+    group.supportsThinking = false;
+  }
   if (info?.supportsImages === true) group.supportsImages = true;
   if (info?.supportsImages === false && group.supportsImages === undefined) {
     group.supportsImages = false;
@@ -216,7 +219,9 @@ function synthesizeModel(
   const routing = routingFromVariants(group.publicId, group.variants, group.unsuffixed);
   const supportsImages = group.supportsImages ?? template?.input.includes("image") ?? true;
   const reasoning =
-    advertisedLevels.size > 0 || group.supportsThinking || Boolean(template?.reasoning);
+    advertisedLevels.size > 0 ||
+    group.supportsThinking === true ||
+    (group.supportsThinking === undefined && Boolean(template?.reasoning));
   return {
     model: {
       id: group.publicId,
@@ -234,7 +239,10 @@ function synthesizeModel(
 
 function advertisedThinkingLevels(group: RuntimeGroup): Set<string> {
   const levels = new Set(Object.keys(group.variants));
-  if (levels.size === 0 && (group.supportsThinking || group.unsuffixed)) {
+  if (levels.size > 0) return levels;
+  // Explicit false from the catalog must not grow a fake High control.
+  if (group.supportsThinking === false) return levels;
+  if (group.supportsThinking === true || group.unsuffixed) {
     levels.add(ThinkingEffort.High);
   }
   return levels;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,4 @@
 export * from "./models.js";
+export * from "./grouping.js";
+export * from "./cache.js";
+export * from "./discovery.js";

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,6 +1,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type { AntigravityRouting } from "../types/types.js";
 import { ThinkingEffort } from "../types/enums.js";
+import type { AntigravityCatalog } from "./grouping.js";
 
 export const PROVIDER_ID = "antigravity";
 export const PROVIDER_NAME = "Antigravity";
@@ -269,9 +270,34 @@ export const ANTIGRAVITY_MODELS: ProviderModelConfig[] = [
   },
 ];
 
+let currentModels: ProviderModelConfig[] = ANTIGRAVITY_MODELS;
+let currentRouting: Record<string, AntigravityRouting> = { ...ANTIGRAVITY_ROUTING };
+
+export function getCurrentAntigravityModels(): ProviderModelConfig[] {
+  return currentModels;
+}
+
+export function getCurrentAntigravityRouting(): Record<string, AntigravityRouting> {
+  return currentRouting;
+}
+
+export function getCurrentAntigravityCatalog(): AntigravityCatalog {
+  return { models: currentModels, routing: currentRouting };
+}
+
+export function applyAntigravityCatalog(catalog: AntigravityCatalog): void {
+  currentModels = catalog.models;
+  currentRouting = catalog.routing;
+}
+
+export function resetAntigravityCatalogForTests(): void {
+  currentModels = ANTIGRAVITY_MODELS;
+  currentRouting = { ...ANTIGRAVITY_ROUTING };
+}
+
 /** Resolve public model id + thinking effort to Antigravity runtime model id. */
 export function getAntigravityRequestModelId(modelId: string, effort: string | undefined): string {
-  const r = ANTIGRAVITY_ROUTING[modelId];
+  const r = currentRouting[modelId] ?? ANTIGRAVITY_ROUTING[modelId];
   if (!r) return modelId;
 
   if (effort === undefined || effort === "off") {
@@ -344,9 +370,6 @@ export function getThinkingConfig(
   modelId: string,
   effort: string | undefined,
 ): ThinkingWire | undefined {
-  if (modelId === "gemini-3.7-flash" || modelId === "gemini-3.6-flash") {
-    return { includeThoughts: true, thinkingLevel: googleLevel(effort) };
-  }
   if (modelId === "gemini-3.5-flash") {
     if (!effort || effort === "off") return { includeThoughts: false, thinkingBudget: 0 };
     const thinkingBudget =
@@ -359,6 +382,9 @@ export function getThinkingConfig(
       includeThoughts: true,
       thinkingBudget: effort === "high" || effort === "xhigh" ? 10_001 : 1_001,
     };
+  }
+  if (modelId.startsWith("gemini-")) {
+    return { includeThoughts: true, thinkingLevel: googleLevel(effort) };
   }
   return undefined;
 }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -384,6 +384,7 @@ export function getThinkingConfig(
     };
   }
   if (modelId.startsWith("gemini-")) {
+    if (!effort || effort === "off") return { includeThoughts: false };
     return { includeThoughts: true, thinkingLevel: googleLevel(effort) };
   }
   return undefined;

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -39,7 +39,7 @@ import {
   ToolChoice,
 } from "../types/enums.js";
 import {
-  ANTIGRAVITY_ROUTING,
+  getCurrentAntigravityRouting,
   getMaxOutputTokens,
   getAntigravityRequestModelId,
   getFallbackRuntimeModel,
@@ -817,7 +817,7 @@ export function streamAntigravity(
       setLastProjectId(projectId);
 
       const effort = opts.reasoning ?? "off";
-      const isKnownModel = model.id in ANTIGRAVITY_ROUTING;
+      const isKnownModel = model.id in getCurrentAntigravityRouting();
       const baseRuntimeModel =
         antigravityEnv("RUNTIME_MODEL")?.trim() || getAntigravityRequestModelId(model.id, effort);
 

--- a/src/usage/usage.ts
+++ b/src/usage/usage.ts
@@ -3,6 +3,7 @@ import {
   antigravityHeaders,
   endpointCandidates,
   extractProjectId,
+  fetchAvailableModelsCatalog,
   parseApiKey,
   resolveProjectId,
 } from "../client/client.js";
@@ -106,90 +107,6 @@ async function postJson(
     }
   }
   throw new Error(`${path} failed: ${lastErrorText || "no endpoint available"}`);
-}
-
-async function fetchAvailableModelsFromEndpoint(
-  endpoint: string,
-  token: string,
-  projectId: string,
-): Promise<{ endpoint: string; status: number; data: unknown } | undefined> {
-  // `{}` and `{ project: projectId }` return byte-identical catalogs on this endpoint
-  // (verified against the live backend) — one body is the full search space per host.
-  try {
-    const res = await antigravityFetch(`${endpoint}/v1internal:fetchAvailableModels`, {
-      method: "POST",
-      headers: jsonHeaders(token),
-      body: JSON.stringify({ project: projectId }),
-    });
-    const text = await res.text();
-    let data: unknown;
-    try {
-      data = JSON.parse(text) as unknown;
-    } catch {
-      data = { raw: text } satisfies ApiErrorBody;
-    }
-    if (!res.ok) {
-      const errorBody = isRecord(data) ? (data as ApiErrorBody) : undefined;
-      const lastErrorText =
-        typeof errorBody?.error?.message === "string" ? errorBody.error.message : text;
-      setLastError(lastErrorText);
-      return undefined;
-    }
-    return { endpoint, status: res.status, data };
-  } catch (error) {
-    setLastError(safeError(error));
-    return undefined;
-  }
-}
-
-/**
- * Merge fetchAvailableModels across endpoint candidates so daily/sandbox-only
- * models (e.g. Gemini 3.6 Flash) appear alongside production catalog entries.
- */
-async function fetchMergedAvailableModels(
-  token: string,
-  projectId: string,
-): Promise<{ endpoint: string; status: number; data: AvailableModelsRaw }> {
-  // Both endpoints are always queried to merge their catalogs — fetch them concurrently
-  // instead of blocking on production before starting the daily/sandbox request.
-  const results = await Promise.all(
-    endpointCandidates().map((endpoint) =>
-      fetchAvailableModelsFromEndpoint(endpoint, token, projectId),
-    ),
-  );
-
-  const mergedModels: Record<string, unknown> = {};
-  let defaultAgentModelId: string | undefined;
-  let lastEndpoint = "";
-  let lastStatus = 0;
-
-  for (const result of results) {
-    if (!result) continue;
-    setLastEndpoint(result.endpoint);
-    setLastStatus(result.status);
-    lastEndpoint = result.endpoint;
-    lastStatus = result.status;
-    const data = result.data;
-    if (isRecord(data) && isRecord(data.models)) {
-      Object.assign(mergedModels, data.models);
-    }
-    if (isRecord(data) && typeof data.defaultAgentModelId === "string") {
-      defaultAgentModelId = data.defaultAgentModelId;
-    }
-  }
-
-  if (!lastEndpoint) {
-    throw new Error(`/v1internal:fetchAvailableModels failed: no endpoint available`);
-  }
-
-  return {
-    endpoint: lastEndpoint,
-    status: lastStatus,
-    data: {
-      models: mergedModels as AvailableModelsRaw["models"],
-      defaultAgentModelId,
-    },
-  };
 }
 
 function parseQuotaSummary(data: unknown): { groups: QuotaGroup[]; description?: string } {
@@ -326,7 +243,7 @@ export async function fetchAccountUsage(apiKeyRaw?: string): Promise<AccountUsag
   const [assistResult, summaryRes, available] = await Promise.all([
     loadCodeAssistSafe(creds.token),
     fetchQuotaSummarySafe(creds.token),
-    fetchMergedAvailableModels(creds.token, initialProjectId),
+    fetchAvailableModelsCatalog(creds.token, initialProjectId),
   ]);
 
   // Derive project ID from the loadCodeAssist response or stored project ID.


### PR DESCRIPTION
## Summary

Supplement the conservative static model catalog with Antigravity's authenticated `fetchAvailableModels` results, allowing newly enabled model IDs to appear without requiring a catalog-only release.

Gemini 3.8 remains statically selectable because some authenticated catalogs omit it. Dynamic discovery exposes whatever additional models the current account and auth tier return.

## Implementation

- Reuse authenticated `v1internal:fetchAvailableModels` fetching from `src/client`.
- Normalize and group runtime variants in `src/models/grouping.ts`.
- Wire Pi's `refreshModels` through `src/models/discovery.ts`.
- Preserve a replace-on-success last-known-good cache and conservative static models.
- Keep existing aliases and Gemini rollout fallbacks unchanged.
- Avoid an `agy` subprocess or new cross-generation fallback behavior.

## Validation

- [x] Unknown `gemini-3.9-flash-low|medium|high` fixture becomes one public `gemini-3.9-flash` model.
- [x] Static Gemini 3.8 remains selectable when the authenticated catalog omits it.
- [x] Unsuffixed unknown runtimes remain selectable.
- [x] Explicit `supportsThinking: false` does not infer reasoning.
- [x] `reasoning=off` disables Gemini thinking.
- [x] Merged catalogs preserve `defaultAgentModel` when `defaultAgentModelId` is omitted.
- [x] Existing aliases, routing, schema handling, and rollout fallbacks remain working.
- [x] Empty or failed discovery does not wipe the last-known-good catalog.
- [x] `bun run check` passes after conflict resolution with current `main`.

Related to #31
