### PR TITLE
fix(stream): isolate unresolved tool schema refs

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -233,6 +233,225 @@ assert.deepEqual(dereferencedCustom?.parameters, {
     status: { type: "string", enum: ["open", "closed"] },
   },
 });
+
+// Resolve complete JSON Pointers, including RFC 6901 escaped property names.
+const nestedPointerTool = {
+  name: "nested_pointer_probe",
+  description: "Tool with an escaped local JSON Pointer",
+  parameters: {
+    type: "object",
+    properties: {
+      accent: { $ref: "#/$defs/Theme/properties/accent~1color" },
+    },
+    $defs: {
+      Theme: {
+        type: "object",
+        properties: {
+          "accent/color": { type: "string" },
+        },
+      },
+    },
+  },
+} as Tool;
+assert.deepEqual(convertTools([nestedPointerTool])?.[0]?.functionDeclarations[0]?.parametersJsonSchema, {
+  type: "object",
+  properties: { accent: { type: "string" } },
+});
+
+// One malformed declaration must not prevent healthy tools from being sent.
+const danglingRefTool = {
+  name: "dangling_ref_probe",
+  description: "Tool with a missing local reference",
+  parameters: {
+    type: "object",
+    properties: { theme: { $ref: "#/$defs/DesignTheme" } },
+  },
+} as Tool;
+const declarationsWithoutDangling = convertTools([refTool, danglingRefTool])?.[0]?.functionDeclarations;
+assert.equal(declarationsWithoutDangling?.length, 1);
+assert.equal(declarationsWithoutDangling?.[0]?.name, "ref_probe");
+assert.equal(convertTools([danglingRefTool]), undefined);
+
+// Recursive references cannot be made self-contained for the Antigravity backend.
+const cyclicRefTool = {
+  name: "cyclic_ref_probe",
+  description: "Tool with a circular local reference",
+  parameters: {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/A" } },
+    $defs: {
+      A: { $ref: "#/$defs/B" },
+      B: { $ref: "#/$defs/A" },
+    },
+  },
+} as Tool;
+assert.equal(convertTools([cyclicRefTool]), undefined);
+
+function unresolvedRefs(value: unknown, path = "$"): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => unresolvedRefs(item, `${path}[${index}]`));
+  }
+  if (!value || typeof value !== "object") return [];
+
+  const schema = value as Record<string, unknown>;
+  const own = typeof schema.$ref === "string" ? [`${path}: ${schema.$ref}`] : [];
+  return [
+    ...own,
+    ...Object.entries(schema).flatMap(([key, child]) => unresolvedRefs(child, `${path}.${key}`)),
+  ];
+}
+
+// Regression: mirrors Stitch's design-system schema, including a nested shared definition.
+const stitchDesignSystemTool = {
+  name: "stitch_design_system_probe",
+  description: "Schema representative of Stitch design-system tools",
+  parameters: {
+    type: "object",
+    properties: {
+      designSystem: {
+        type: "object",
+        properties: {
+          theme: {
+            $ref: "#/$defs/DesignTheme",
+            description: "Required theme configuration",
+          },
+        },
+        required: ["theme"],
+      },
+    },
+    required: ["designSystem"],
+    $defs: {
+      Font: { type: "string", enum: ["INTER", "MANROPE"] },
+      DesignTheme: {
+        type: "object",
+        properties: {
+          bodyFont: { $ref: "#/$defs/Font" },
+          headlineFont: { $ref: "#/$defs/Font" },
+          colorMode: { type: "string", enum: ["LIGHT", "DARK"] },
+        },
+        required: ["bodyFont", "headlineFont", "colorMode"],
+      },
+    },
+  },
+} as Tool;
+const stitchSchema = convertTools([stitchDesignSystemTool])?.[0]?.functionDeclarations[0]
+  ?.parametersJsonSchema as Record<string, unknown>;
+assert.ok(stitchSchema);
+assert.deepEqual(unresolvedRefs(stitchSchema), []);
+assert.deepEqual(
+  (stitchSchema.properties as Record<string, Record<string, unknown>>).designSystem.properties,
+  {
+    theme: {
+      type: "object",
+      properties: {
+        bodyFont: { type: "string", enum: ["INTER", "MANROPE"] },
+        headlineFont: { type: "string", enum: ["INTER", "MANROPE"] },
+        colorMode: { type: "string", enum: ["LIGHT", "DARK"] },
+      },
+      required: ["bodyFont", "headlineFont", "colorMode"],
+      description: "Required theme configuration",
+    },
+  },
+);
+
+// Resolve both Draft-07 definitions and repeated nested references without global visitation.
+const sharedReferenceTool = {
+  name: "shared_reference_probe",
+  description: "Tool with repeated references to a shared nested schema",
+  parameters: {
+    type: "object",
+    properties: {
+      primary: { $ref: "#/definitions/Theme" },
+      secondary: { $ref: "#/definitions/Theme" },
+      accents: { type: "array", items: { $ref: "#/definitions/Color" } },
+    },
+    definitions: {
+      Color: { type: "string", enum: ["red", "blue"] },
+      Theme: {
+        type: "object",
+        properties: {
+          foreground: { $ref: "#/definitions/Color" },
+          background: { $ref: "#/definitions/Color" },
+        },
+      },
+    },
+  },
+} as Tool;
+const sharedSchema = convertTools([sharedReferenceTool])?.[0]?.functionDeclarations[0]
+  ?.parametersJsonSchema as Record<string, unknown>;
+assert.ok(sharedSchema);
+assert.deepEqual(unresolvedRefs(sharedSchema), []);
+assert.deepEqual(
+  (sharedSchema.properties as Record<string, Record<string, unknown>>).accents.items,
+  { type: "string", enum: ["red", "blue"] },
+);
+
+// References embedded in JSON Schema combinators are traversed like MCP tool schemas from Zod/Ajv.
+const combinatorReferenceTool = {
+  name: "combinator_reference_probe",
+  description: "Tool with refs in schema combinators",
+  parameters: {
+    type: "object",
+    properties: {
+      value: {
+        anyOf: [
+          { $ref: "#/$defs/Text" },
+          { type: "array", items: { $ref: "#/$defs/Text" } },
+        ],
+      },
+      constrained: {
+        allOf: [{ $ref: "#/$defs/Text" }],
+      },
+    },
+    $defs: { Text: { type: "string", minLength: 1 } },
+  },
+} as Tool;
+const combinatorSchema = convertTools([combinatorReferenceTool])?.[0]?.functionDeclarations[0]
+  ?.parametersJsonSchema;
+assert.ok(combinatorSchema);
+assert.deepEqual(unresolvedRefs(combinatorSchema), []);
+
+// RFC 6901 supports both '~' and '/' escaping in property names.
+const fullyEscapedPointerTool = {
+  name: "fully_escaped_pointer_probe",
+  description: "Tool with a fully escaped JSON Pointer",
+  parameters: {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/Envelope/properties/a~0b~1c" } },
+    $defs: {
+      Envelope: { type: "object", properties: { "a~b/c": { type: "boolean" } } },
+    },
+  },
+} as Tool;
+assert.deepEqual(
+  convertTools([fullyEscapedPointerTool])?.[0]?.functionDeclarations[0]?.parametersJsonSchema,
+  { type: "object", properties: { value: { type: "boolean" } } },
+);
+
+// MCP servers can expose external or malformed refs. They are isolated instead of poisoning all tools.
+const externalRefTool = {
+  name: "external_ref_probe",
+  description: "Tool with an unsupported external reference",
+  parameters: {
+    type: "object",
+    properties: { value: { $ref: "https://example.test/schema.json#/Value" } },
+  },
+} as Tool;
+const schemasWithExternalRef = convertTools([refTool, externalRefTool])?.[0]?.functionDeclarations;
+assert.equal(schemasWithExternalRef?.length, 1);
+assert.equal(schemasWithExternalRef?.[0]?.name, "ref_probe");
+
+// The legacy Claude/GPT bridge receives the same fully inlined schema before its allowlist pass.
+const legacyStitchSchema = convertTools([stitchDesignSystemTool], true)?.[0]
+  ?.functionDeclarations[0]?.parameters as Record<string, unknown>;
+assert.ok(legacyStitchSchema);
+assert.deepEqual(unresolvedRefs(legacyStitchSchema), []);
+assert.deepEqual(
+  ((legacyStitchSchema.properties as Record<string, Record<string, unknown>>).designSystem
+    .properties as Record<string, Record<string, unknown>>).theme.type,
+  "object",
+);
+
 assert.match(
   friendlyAntigravityError(400, JSON.stringify({ error: { message: "Unknown name nullable" } })),
   /Unknown name nullable/i,

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -1,5 +1,6 @@
 import type { Api, Context, Model, Tool } from "@earendil-works/pi-ai";
 import { defaultProjectId, stableProjectId } from "../src/client/index.js";
+import { getLastDiagnostics, resetDiagnosticsForTests } from "../src/diagnostics/index.js";
 import { StopReason } from "../src/types/enums.js";
 import {
   ANTIGRAVITY_MODELS,
@@ -267,9 +268,11 @@ const danglingRefTool = {
     properties: { theme: { $ref: "#/$defs/DesignTheme" } },
   },
 } as Tool;
+resetDiagnosticsForTests();
 const declarationsWithoutDangling = convertTools([refTool, danglingRefTool])?.[0]?.functionDeclarations;
 assert.equal(declarationsWithoutDangling?.length, 1);
 assert.equal(declarationsWithoutDangling?.[0]?.name, "ref_probe");
+assert.match(getLastDiagnostics().toolSchemaWarnings || "", /dangling_ref_probe.*not present/i);
 assert.equal(convertTools([danglingRefTool]), undefined);
 
 // Recursive references cannot be made self-contained for the Antigravity backend.
@@ -287,6 +290,7 @@ const cyclicRefTool = {
 } as Tool;
 assert.equal(convertTools([cyclicRefTool]), undefined);
 
+/** Return every unresolved reference emitted in a converted declaration. */
 function unresolvedRefs(value: unknown, path = "$"): string[] {
   if (Array.isArray(value)) {
     return value.flatMap((item, index) => unresolvedRefs(item, `${path}[${index}]`));
@@ -427,6 +431,59 @@ assert.deepEqual(
   convertTools([fullyEscapedPointerTool])?.[0]?.functionDeclarations[0]?.parametersJsonSchema,
   { type: "object", properties: { value: { type: "boolean" } } },
 );
+
+// RFC 6901 array tokens resolve schemas selected from combinator arrays.
+const arrayPointerTool = {
+  name: "array_pointer_probe",
+  description: "Tool with an array-index local JSON Pointer",
+  parameters: {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/Value/anyOf/0" } },
+    $defs: { Value: { anyOf: [{ type: "integer" }, { type: "string" }] } },
+  },
+} as Tool;
+assert.deepEqual(
+  convertTools([arrayPointerTool])?.[0]?.functionDeclarations[0]?.parametersJsonSchema,
+  { type: "object", properties: { value: { type: "integer" } } },
+);
+
+// Property names may themselves be JSON Schema keywords and must remain ordinary property names.
+const keywordNamedPropertiesTool = {
+  name: "keyword_named_properties_probe",
+  description: "Tool with keyword-like property names",
+  parameters: {
+    type: "object",
+    properties: {
+      definitions: { type: "string" },
+      $ref: { type: "number" },
+    },
+  },
+} as Tool;
+assert.deepEqual(
+  convertTools([keywordNamedPropertiesTool])?.[0]?.functionDeclarations[0]?.parametersJsonSchema,
+  {
+    type: "object",
+    properties: { definitions: { type: "string" }, $ref: { type: "number" } },
+  },
+);
+
+// Bound fan-out from untrusted MCP schemas instead of expanding references indefinitely.
+const expansionBudgetTool = {
+  name: "expansion_budget_probe",
+  description: "Tool with excessive repeated references",
+  parameters: {
+    type: "object",
+    properties: {
+      value: {
+        anyOf: Array.from({ length: 4_000 }, () => ({ $ref: "#/$defs/Value" })),
+      },
+    },
+    $defs: { Value: { type: "string" } },
+  },
+} as Tool;
+resetDiagnosticsForTests();
+assert.equal(convertTools([expansionBudgetTool]), undefined);
+assert.match(getLastDiagnostics().toolSchemaWarnings || "", /expansion exceeded.*nodes/i);
 
 // MCP servers can expose external or malformed refs. They are isolated instead of poisoning all tools.
 const externalRefTool = {

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -390,6 +390,40 @@ assert.deepEqual(
   { type: "string", enum: ["red", "blue"] },
 );
 
+// Draft-07 dependencies may contain schemas with references or property-name arrays.
+const dependencyReferenceTool = {
+  name: "dependency_reference_probe",
+  description: "Tool with a referenced dependency schema",
+  parameters: {
+    type: "object",
+    properties: {
+      enabled: { type: "boolean" },
+      mode: { type: "string" },
+    },
+    dependencies: {
+      enabled: { $ref: "#/definitions/EnabledOptions" },
+      mode: ["enabled"],
+    },
+    definitions: {
+      EnabledOptions: {
+        type: "object",
+        properties: { threshold: { type: "number" } },
+      },
+    },
+  },
+} as Tool;
+const dependencySchema = convertTools([dependencyReferenceTool])?.[0]?.functionDeclarations[0]
+  ?.parametersJsonSchema as Record<string, unknown>;
+assert.ok(dependencySchema);
+assert.deepEqual(unresolvedRefs(dependencySchema), []);
+assert.deepEqual(dependencySchema.dependencies, {
+  enabled: {
+    type: "object",
+    properties: { threshold: { type: "number" } },
+  },
+  mode: ["enabled"],
+});
+
 // References embedded in JSON Schema combinators are traversed like MCP tool schemas from Zod/Ajv.
 const combinatorReferenceTool = {
   name: "combinator_reference_probe",

--- a/src/diagnostics/diagnostics.ts
+++ b/src/diagnostics/diagnostics.ts
@@ -12,6 +12,7 @@ export type DiagnosticsSnapshot = {
   latencyMs?: number;
   maskedEmail?: string;
   tokenExpiry?: string;
+  toolSchemaWarnings?: string;
 };
 
 const storage = new AsyncLocalStorage<DiagnosticsSnapshot>();
@@ -82,6 +83,10 @@ export function setLastMaskedEmail(email: string | undefined): void {
 }
 export function setLastTokenExpiry(expiry: string | undefined): void {
   currentBag().tokenExpiry = expiry;
+}
+export function setLastToolSchemaWarnings(warnings: string[] | undefined): void {
+  currentBag().toolSchemaWarnings =
+    warnings === undefined ? undefined : redactSecrets(warnings.join(" | ")).slice(0, 1200);
 }
 
 /** Test helper: reset last snapshot between cases. */

--- a/src/diagnostics/diagnostics.ts
+++ b/src/diagnostics/diagnostics.ts
@@ -84,6 +84,7 @@ export function setLastMaskedEmail(email: string | undefined): void {
 export function setLastTokenExpiry(expiry: string | undefined): void {
   currentBag().tokenExpiry = expiry;
 }
+/** Store sanitized tool-schema omissions for the next doctor report. */
 export function setLastToolSchemaWarnings(warnings: string[] | undefined): void {
   currentBag().toolSchemaWarnings =
     warnings === undefined ? undefined : redactSecrets(warnings.join(" | ")).slice(0, 1200);

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ export default function (pi: ExtensionAPI): void {
         `lastStatus=${d.status ?? "none"}`,
         `lastProjectId=${d.projectId || "none"}`,
         ...(d.latencyMs !== undefined ? [`lastLatencyMs=${d.latencyMs}`] : []),
+        `toolSchemaWarnings=${d.toolSchemaWarnings || "none"}`,
         `lastError=${d.error ? redactSecrets(d.error) : "none"}`,
         "transport=native-streamSimple",
         "runtimeCli=not-used",

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -319,7 +319,12 @@ type DereferenceState = {
 
 const MAX_SCHEMA_DEREFERENCE_DEPTH = 64;
 const MAX_SCHEMA_DEREFERENCE_NODES = 10_000;
-const SCHEMA_MAP_KEYWORDS = new Set(["properties", "patternProperties", "dependentSchemas"]);
+const SCHEMA_MAP_KEYWORDS = new Set([
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+  "dependencies",
+]);
 const SCHEMA_VALUE_KEYWORDS = new Set([
   "additionalItems",
   "additionalProperties",

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -29,6 +29,7 @@ import {
   setLastProjectId,
   setLastResolvedRuntimeModel,
   setLastStatus,
+  setLastToolSchemaWarnings,
 } from "../diagnostics/diagnostics.js";
 import {
   AntigravityRequestType,
@@ -301,43 +302,119 @@ export function convertMessages(
   return contents;
 }
 
+type SchemaReferenceIssue = {
+  path: string;
+  ref: string;
+  reason: string;
+};
+
+type DereferencedSchema = {
+  schema: unknown;
+  issues: SchemaReferenceIssue[];
+};
+
+/** Resolve a local RFC 6901 JSON Pointer against the original tool schema. */
+function resolveLocalJsonPointer(ref: string, rootSchema: unknown): unknown {
+  if (ref === "#") return rootSchema;
+  if (!ref.startsWith("#/")) return undefined;
+
+  let current: unknown = rootSchema;
+  for (const token of ref.slice(2).split("/")) {
+    const key = token.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, key)) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/**
+ * Gemini rejects dangling JSON Schema references. Inline every reachable local
+ * reference and report references that cannot be made self-contained so the
+ * affected tool can be omitted without breaking every other tool declaration.
+ */
 function dereferenceSchema(
   schema: unknown,
-  rootDefs: Record<string, unknown> = {},
-  visited = new Set<unknown>(),
-): unknown {
-  if (!schema || typeof schema !== "object") return schema;
+  rootSchema: unknown = schema,
+  refStack = new Set<string>(),
+  objectStack = new Set<object>(),
+  path = "$",
+): DereferencedSchema {
+  if (!schema || typeof schema !== "object") return { schema, issues: [] };
+
   if (Array.isArray(schema)) {
-    return schema.map((item) => dereferenceSchema(item, rootDefs, visited));
+    const results = schema.map((item, index) =>
+      dereferenceSchema(item, rootSchema, refStack, objectStack, `${path}[${index}]`),
+    );
+    return {
+      schema: results.map((result) => result.schema),
+      issues: results.flatMap((result) => result.issues),
+    };
   }
 
   const s = schema as Record<string, unknown>;
-  if (visited.has(s)) return s;
-  visited.add(s);
+  if (objectStack.has(s)) {
+    return {
+      schema: {},
+      issues: [{ path, ref: "(object cycle)", reason: "circular schema object" }],
+    };
+  }
 
-  const defs: Record<string, unknown> = { ...rootDefs };
-  if (isRecord(s.$defs)) Object.assign(defs, s.$defs);
-  if (isRecord(s.definitions)) Object.assign(defs, s.definitions);
+  const nextObjectStack = new Set(objectStack);
+  nextObjectStack.add(s);
 
   if (typeof s.$ref === "string") {
     const ref = s.$ref;
-    const match = ref.match(/^#\/(?:\$defs|definitions)\/(.+)$/);
-    if (match && match[1] && defs[match[1]] !== undefined) {
-      const resolved = dereferenceSchema(defs[match[1]], defs, visited);
-      if (isRecord(resolved)) {
-        const { $ref: _, ...rest } = s;
-        const restCleaned = dereferenceSchema(rest, defs, visited);
-        return isRecord(restCleaned) ? { ...resolved, ...restCleaned } : resolved;
-      }
-      return resolved;
+    if (refStack.has(ref)) {
+      return {
+        schema: {},
+        issues: [{ path, ref, reason: "circular local reference" }],
+      };
     }
+
+    const target = resolveLocalJsonPointer(ref, rootSchema);
+    if (target === undefined) {
+      return {
+        schema: {},
+        issues: [{ path, ref, reason: "target is not present in the root schema" }],
+      };
+    }
+
+    const nextRefStack = new Set(refStack);
+    nextRefStack.add(ref);
+    const resolved = dereferenceSchema(target, rootSchema, nextRefStack, nextObjectStack, path);
+    const { $ref: _, ...siblings } = s;
+    const siblingResult = dereferenceSchema(siblings, rootSchema, refStack, nextObjectStack, path);
+
+    if (isRecord(resolved.schema) && isRecord(siblingResult.schema)) {
+      return {
+        schema: { ...resolved.schema, ...siblingResult.schema },
+        issues: [...resolved.issues, ...siblingResult.issues],
+      };
+    }
+    return {
+      schema: resolved.schema,
+      issues: [...resolved.issues, ...siblingResult.issues],
+    };
   }
 
   const out: Record<string, unknown> = {};
+  const issues: SchemaReferenceIssue[] = [];
   for (const [key, value] of Object.entries(s)) {
-    out[key] = dereferenceSchema(value, defs, visited);
+    // Definitions are available through rootSchema while resolving $ref, but must
+    // not be emitted because the Antigravity backend requires self-contained schemas.
+    if (key === "$defs" || key === "definitions") continue;
+    const result = dereferenceSchema(
+      value,
+      rootSchema,
+      refStack,
+      nextObjectStack,
+      `${path}.${key}`,
+    );
+    out[key] = result.schema;
+    issues.push(...result.issues);
   }
-  return out;
+  return { schema: out, issues };
 }
 
 function ensureRootObjectSchema(schema: unknown): Record<string, unknown> {
@@ -439,22 +516,34 @@ export function convertTools(
   useLegacyParameters = false,
 ): { functionDeclarations: GeminiFunctionDeclaration[] }[] | undefined {
   if (!tools?.length) return undefined;
-  return [
-    {
-      functionDeclarations: tools.map((tool) => {
-        const dereferenced = dereferenceSchema(tool.parameters);
-        const rootObject = ensureRootObjectSchema(dereferenced);
-        const schema = stripMetaSchema(rootObject);
-        return {
-          name: tool.name,
-          description: tool.description,
-          ...(useLegacyParameters
-            ? { parameters: normalizeCustomToolSchema(schema) }
-            : { parametersJsonSchema: schema }),
-        };
-      }),
-    },
-  ];
+
+  const warnings: string[] = [];
+  const functionDeclarations = tools.flatMap((tool) => {
+    const dereferenced = dereferenceSchema(tool.parameters);
+    if (dereferenced.issues.length > 0) {
+      const detail = dereferenced.issues
+        .map((issue) => `${issue.path} (${issue.ref}: ${issue.reason})`)
+        .join(", ");
+      warnings.push(`Skipped tool '${tool.name}' due to unresolved schema reference: ${detail}`);
+      return [];
+    }
+
+    const rootObject = ensureRootObjectSchema(dereferenced.schema);
+    const schema = stripMetaSchema(rootObject);
+    return [
+      {
+        name: tool.name,
+        description: tool.description,
+        ...(useLegacyParameters
+          ? { parameters: normalizeCustomToolSchema(schema) }
+          : { parametersJsonSchema: schema }),
+      },
+    ];
+  });
+
+  setLastToolSchemaWarnings(warnings.length ? warnings : undefined);
+  if (!functionDeclarations.length) return undefined;
+  return [{ functionDeclarations }];
 }
 
 function mapToolChoiceMode(

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -313,6 +313,29 @@ type DereferencedSchema = {
   issues: SchemaReferenceIssue[];
 };
 
+type DereferenceState = {
+  nodes: number;
+};
+
+const MAX_SCHEMA_DEREFERENCE_DEPTH = 64;
+const MAX_SCHEMA_DEREFERENCE_NODES = 10_000;
+const SCHEMA_MAP_KEYWORDS = new Set(["properties", "patternProperties", "dependentSchemas"]);
+const SCHEMA_VALUE_KEYWORDS = new Set([
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "contentSchema",
+  "else",
+  "if",
+  "items",
+  "not",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+const SCHEMA_ARRAY_KEYWORDS = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+
 /** Resolve a local RFC 6901 JSON Pointer against the original tool schema. */
 function resolveLocalJsonPointer(ref: string, rootSchema: unknown): unknown {
   if (ref === "#") return rootSchema;
@@ -321,30 +344,103 @@ function resolveLocalJsonPointer(ref: string, rootSchema: unknown): unknown {
   let current: unknown = rootSchema;
   for (const token of ref.slice(2).split("/")) {
     const key = token.replace(/~1/g, "/").replace(/~0/g, "~");
-    if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
+    if (Array.isArray(current)) {
+      if (!/^(0|[1-9]\d*)$/.test(key)) return undefined;
+      const index = Number(key);
+      if (!Number.isSafeInteger(index) || index >= current.length) return undefined;
+      current = current[index];
+      continue;
+    }
+    if (!current || typeof current !== "object") return undefined;
     if (!Object.prototype.hasOwnProperty.call(current, key)) return undefined;
     current = (current as Record<string, unknown>)[key];
   }
   return current;
 }
 
+/** Dereference every schema in a keyword map without interpreting map keys as JSON Schema keywords. */
+function dereferenceSchemaMap(
+  schemaMap: unknown,
+  rootSchema: unknown,
+  refStack: Set<string>,
+  objectStack: Set<object>,
+  state: DereferenceState,
+  path: string,
+  depth: number,
+): DereferencedSchema {
+  if (!isRecord(schemaMap)) {
+    return dereferenceSchema(schemaMap, rootSchema, refStack, objectStack, state, path, depth);
+  }
+
+  const out: Record<string, unknown> = {};
+  const issues: SchemaReferenceIssue[] = [];
+  for (const [key, value] of Object.entries(schemaMap)) {
+    const result = dereferenceSchema(
+      value,
+      rootSchema,
+      refStack,
+      objectStack,
+      state,
+      `${path}.${key}`,
+      depth,
+    );
+    out[key] = result.schema;
+    issues.push(...result.issues);
+  }
+  return { schema: out, issues };
+}
+
 /**
- * Gemini rejects dangling JSON Schema references. Inline every reachable local
- * reference and report references that cannot be made self-contained so the
- * affected tool can be omitted without breaking every other tool declaration.
+ * Inline reachable local references while bounding expansion of untrusted MCP schemas.
+ * A reported issue causes only the affected tool declaration to be omitted.
  */
 function dereferenceSchema(
   schema: unknown,
   rootSchema: unknown = schema,
   refStack = new Set<string>(),
   objectStack = new Set<object>(),
+  state: DereferenceState = { nodes: 0 },
   path = "$",
+  depth = 0,
 ): DereferencedSchema {
+  if (depth > MAX_SCHEMA_DEREFERENCE_DEPTH) {
+    return {
+      schema: {},
+      issues: [
+        {
+          path,
+          ref: "(depth limit)",
+          reason: `schema expansion exceeded ${MAX_SCHEMA_DEREFERENCE_DEPTH} levels`,
+        },
+      ],
+    };
+  }
+  state.nodes += 1;
+  if (state.nodes > MAX_SCHEMA_DEREFERENCE_NODES) {
+    return {
+      schema: {},
+      issues: [
+        {
+          path,
+          ref: "(node limit)",
+          reason: `schema expansion exceeded ${MAX_SCHEMA_DEREFERENCE_NODES} nodes`,
+        },
+      ],
+    };
+  }
   if (!schema || typeof schema !== "object") return { schema, issues: [] };
 
   if (Array.isArray(schema)) {
     const results = schema.map((item, index) =>
-      dereferenceSchema(item, rootSchema, refStack, objectStack, `${path}[${index}]`),
+      dereferenceSchema(
+        item,
+        rootSchema,
+        refStack,
+        objectStack,
+        state,
+        `${path}[${index}]`,
+        depth + 1,
+      ),
     );
     return {
       schema: results.map((result) => result.schema),
@@ -382,9 +478,25 @@ function dereferenceSchema(
 
     const nextRefStack = new Set(refStack);
     nextRefStack.add(ref);
-    const resolved = dereferenceSchema(target, rootSchema, nextRefStack, nextObjectStack, path);
+    const resolved = dereferenceSchema(
+      target,
+      rootSchema,
+      nextRefStack,
+      nextObjectStack,
+      state,
+      path,
+      depth + 1,
+    );
     const { $ref: _, ...siblings } = s;
-    const siblingResult = dereferenceSchema(siblings, rootSchema, refStack, nextObjectStack, path);
+    const siblingResult = dereferenceSchema(
+      siblings,
+      rootSchema,
+      refStack,
+      nextObjectStack,
+      state,
+      path,
+      depth + 1,
+    );
 
     if (isRecord(resolved.schema) && isRecord(siblingResult.schema)) {
       return {
@@ -404,15 +516,36 @@ function dereferenceSchema(
     // Definitions are available through rootSchema while resolving $ref, but must
     // not be emitted because the Antigravity backend requires self-contained schemas.
     if (key === "$defs" || key === "definitions") continue;
-    const result = dereferenceSchema(
-      value,
-      rootSchema,
-      refStack,
-      nextObjectStack,
-      `${path}.${key}`,
-    );
-    out[key] = result.schema;
-    issues.push(...result.issues);
+
+    let result: DereferencedSchema | undefined;
+    if (SCHEMA_MAP_KEYWORDS.has(key)) {
+      result = dereferenceSchemaMap(
+        value,
+        rootSchema,
+        refStack,
+        nextObjectStack,
+        state,
+        `${path}.${key}`,
+        depth + 1,
+      );
+    } else if (SCHEMA_VALUE_KEYWORDS.has(key) || SCHEMA_ARRAY_KEYWORDS.has(key)) {
+      result = dereferenceSchema(
+        value,
+        rootSchema,
+        refStack,
+        nextObjectStack,
+        state,
+        `${path}.${key}`,
+        depth + 1,
+      );
+    }
+
+    if (result) {
+      out[key] = result.schema;
+      issues.push(...result.issues);
+    } else {
+      out[key] = value;
+    }
   }
   return { schema: out, issues };
 }
@@ -427,21 +560,40 @@ function ensureRootObjectSchema(schema: unknown): Record<string, unknown> {
   return schema;
 }
 
+const META_SCHEMA_KEYWORDS = new Set([
+  "$schema",
+  "$id",
+  "$anchor",
+  "$dynamicAnchor",
+  "$vocabulary",
+  "$comment",
+  "$defs",
+  "definitions",
+]);
+
+/** Remove schema metadata without treating user-defined property names as keywords. */
+function stripMetaSchemaMap(schemaMap: unknown): unknown {
+  if (!isRecord(schemaMap)) return stripMetaSchema(schemaMap);
+  return Object.fromEntries(
+    Object.entries(schemaMap).map(([key, value]) => [key, stripMetaSchema(value)]),
+  );
+}
+
+/** Remove metadata that Cloud Code Assist rejects from JSON Schema keyword positions. */
 function stripMetaSchema(schema: unknown): unknown {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
-  const omit = new Set([
-    "$schema",
-    "$id",
-    "$anchor",
-    "$dynamicAnchor",
-    "$vocabulary",
-    "$comment",
-    "$defs",
-    "definitions",
-  ]);
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(stripMetaSchema);
+
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
-    if (!omit.has(key)) out[key] = stripMetaSchema(value);
+    if (META_SCHEMA_KEYWORDS.has(key)) continue;
+    if (SCHEMA_MAP_KEYWORDS.has(key)) {
+      out[key] = stripMetaSchemaMap(value);
+    } else if (SCHEMA_VALUE_KEYWORDS.has(key) || SCHEMA_ARRAY_KEYWORDS.has(key)) {
+      out[key] = stripMetaSchema(value);
+    } else {
+      out[key] = value;
+    }
   }
   return out;
 }


### PR DESCRIPTION
# Pull request

## Summary

- Inline local JSON Schema `$ref` values using full JSON Pointer resolution before removing `$defs`/`definitions`.
- Skip only declarations with unresolved, external, or cyclic references and surface the reason in `/antigravity.doctor`.
- Prevents Gemini 400 errors such as `reference to undefined schema at properties.designSystem.properties.theme` when Stitch tools are active.

## Validation

- [ ] `bun run check` — blocked only by pre-existing formatting failures in untouched files
- [x] Tests added or updated when behavior changed
- [x] `bun run typecheck`, `bun run lint`, security check, and full test suite passed
- [x] Live requests passed with Gemini 3.7/3.8, Claude Sonnet, and GPT-OSS
- [x] Documentation not required; no user-facing command or configuration changed

## Security

- [x] No credentials, tokens, secrets, or private account data are included
- [x] Security implications have been considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of tool schemas with nested, escaped, repeated, and legacy references.
  - Detects missing, circular, or excessively expanded schema references and prevents invalid tool declarations from being used.
  - Valid tool declarations remain available when other tools contain malformed schemas.

- **Diagnostics**
  - The `antigravity.doctor` command now reports tool-schema warnings.
  - Warnings are sanitized and limited in length to avoid exposing sensitive information.

- **Tests**
  - Added regression coverage for references, cycles, combinators, JSON pointers, and mixed valid/invalid tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->