### PR TITLE
feat: add response-header deadline for streaming requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "security-check": "bun scripts/security-check.ts",
-    "test": "bun scripts/test-model-routing.ts && bun scripts/test-model-discovery.ts && bun scripts/test-usage-formatter.ts && bun scripts/test-stream-sse.ts && bun scripts/test-http-proxy.ts && bun scripts/test-image-gen.ts",
+    "test": "bun scripts/test-model-routing.ts && bun scripts/test-model-discovery.ts && bun scripts/test-usage-formatter.ts && bun scripts/test-stream-sse.ts && bun scripts/test-stream-header-deadline.ts && bun scripts/test-http-proxy.ts && bun scripts/test-image-gen.ts",
     "smoke:tools": "bun scripts/smoke-tool-schema.ts",
     "smoke:models": "bun scripts/smoke-all-models.mjs",
     "check": "bun run typecheck && bun run lint && bun run format:check && bun run security-check && bun run test"

--- a/scripts/test-stream-header-deadline.ts
+++ b/scripts/test-stream-header-deadline.ts
@@ -1,11 +1,15 @@
 /**
- * Header-deadline tests for fetchWithHeaderDeadline:
+ * Guard tests for fetchWithHeaderDeadline (header phase + body-stall phase):
  * 1. A server that accepts the request but never sends headers must fail fast
  *    with a named error once the deadline elapses.
  * 2. A fast-headers fetch must succeed well inside the deadline (timer disarmed).
  * 3. Fast headers + slow body must stream to completion even when the body
- *    outlives the deadline — the deadline covers only the header phase.
+ *    outlives the HEADER deadline — that deadline covers only the header phase.
  * 4. A deadline of 0 must disable the mechanism entirely.
+ * 5. Headers that arrive and then a body that goes silent must abort with a
+ *    named stall error once the stall deadline elapses.
+ * 6. A body that keeps emitting chunks slower than the total runtime but faster
+ *    than the stall deadline must complete — only silence aborts.
  */
 import { fetchWithHeaderDeadline } from "../src/stream/stream.js";
 
@@ -16,7 +20,6 @@ function assert(condition: unknown, message: string): void {
 function hangForever(_url: string, init: RequestInit): Promise<Response> {
   return new Promise((_resolve, reject) => {
     init.signal?.addEventListener("abort", () => {
-      // Mirror fetch semantics: reject with the abort reason when provided.
       const signal = init.signal as AbortSignal & { reason?: unknown };
       reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
     });
@@ -26,14 +29,33 @@ function hangForever(_url: string, init: RequestInit): Promise<Response> {
 function immediateResponse(_url: string, _init: RequestInit): Promise<Response> {
   return Promise.resolve(new Response("ok"));
 }
-
-function slowBodyResponse(_url: string, _init: RequestInit): Promise<Response> {
-  // Headers resolve instantly; the body takes 120ms — longer than every deadline
-  // used in these tests.
+/** Headers resolve instantly; body emits one chunk then never another. */
+function silentAfterFirstChunk(_url: string, init: RequestInit): Promise<Response> {
   const body = new ReadableStream<Uint8Array>({
     async pull(controller) {
-      await new Promise((res) => setTimeout(res, 30));
-      controller.enqueue(new TextEncoder().encode("chunk"));
+      controller.enqueue(new TextEncoder().encode("data: first\n\n"));
+      // Emulate undici: aborting the fetch signal errors the body stream with
+      // the abort reason; silence otherwise lasts forever.
+      await new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const signal = init.signal as AbortSignal & { reason?: unknown };
+          reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+        });
+      });
+      controller.close();
+    },
+  });
+  return Promise.resolve(new Response(body));
+}
+
+/** Body emits a chunk every 20ms — slower overall, never silent past 60ms. */
+function chunkyBody(_url: string, _init: RequestInit): Promise<Response> {
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      for (let i = 0; i < 5; i++) {
+        await new Promise((res) => setTimeout(res, 20));
+        controller.enqueue(new TextEncoder().encode(`data: chunk${i}\n\n`));
+      }
       controller.close();
     },
   });
@@ -44,7 +66,7 @@ async function main(): Promise<void> {
   // 1. Tarpit: never resolves, deadline fires with the named error.
   let sawTarpitError = false;
   try {
-    await fetchWithHeaderDeadline("https://x", {}, undefined, 40, hangForever);
+    await fetchWithHeaderDeadline("https://x", {}, undefined, 40, 0, hangForever);
     throw new Error("expected the tarpit fetch to reject");
   } catch (error) {
     sawTarpitError = error instanceof Error && /no response headers within 40ms/.test(error.message);
@@ -52,17 +74,17 @@ async function main(): Promise<void> {
   assert(sawTarpitError, "tarpit fetch should fail with the named header-deadline error");
 
   // 2. Fast headers inside the deadline succeed.
-  const fast = await fetchWithHeaderDeadline("https://x", {}, undefined, 5000, immediateResponse);
+  const fast = await fetchWithHeaderDeadline("https://x", {}, undefined, 5000, 0, immediateResponse);
   assert(fast.ok, "fast fetch should succeed inside the deadline");
 
-  // 3. Slow body outlives the deadline but headers arrived: must complete.
-  const slow = await fetchWithHeaderDeadline("https://x", {}, undefined, 40, slowBodyResponse);
-  assert(slow.ok, "slow-body fetch must complete once headers arrived inside the deadline");
+  // 3. Slow body outlives the HEADER deadline but headers arrived: must complete.
+  const slow = await fetchWithHeaderDeadline("https://x", {}, undefined, 40, 0, chunkyBody);
+  assert((await slow.text()).includes("chunk4"), "slow-body fetch must complete once headers arrived");
 
-  // 4. Deadline 0 disables the mechanism (hang would otherwise fire at any ms).
+  // 4. Deadlines of 0 disable the mechanism.
   let sawDisablePath = false;
   try {
-    await fetchWithHeaderDeadline("https://x", {}, undefined, 0, (_u, i) => {
+    await fetchWithHeaderDeadline("https://x", {}, undefined, 0, 0, (_u, i) => {
       sawDisablePath = i.signal === undefined;
       return Promise.resolve(new Response("ok"));
     });
@@ -70,6 +92,21 @@ async function main(): Promise<void> {
     throw new Error("deadline 0 must not inject an abort signal");
   }
   assert(sawDisablePath, "deadline 0 should pass init through without a signal");
+
+  // 5. Mid-body stall: headers fine, body silent — named stall error.
+  let sawStallError = false;
+  try {
+    const stalled = await fetchWithHeaderDeadline("https://x", {}, undefined, 5000, 40, silentAfterFirstChunk);
+    await stalled.text();
+    throw new Error("expected the stalled body to reject");
+  } catch (error) {
+    sawStallError = error instanceof Error && /no data for 40ms/.test(error.message);
+  }
+  assert(sawStallError, `silent body should abort with the named stall error (got: ${sawStallError})`);
+
+  // 6. Chunks every 20ms with 60ms stall deadline: no false positive.
+  const steady = await fetchWithHeaderDeadline("https://x", {}, undefined, 5000, 60, chunkyBody);
+  assert((await steady.text()).includes("chunk4"), "steady chunks must complete without a stall abort");
 
   console.log("test-stream-header-deadline: all assertions passed");
 }

--- a/scripts/test-stream-header-deadline.ts
+++ b/scripts/test-stream-header-deadline.ts
@@ -1,0 +1,77 @@
+/**
+ * Header-deadline tests for fetchWithHeaderDeadline:
+ * 1. A server that accepts the request but never sends headers must fail fast
+ *    with a named error once the deadline elapses.
+ * 2. A fast-headers fetch must succeed well inside the deadline (timer disarmed).
+ * 3. Fast headers + slow body must stream to completion even when the body
+ *    outlives the deadline — the deadline covers only the header phase.
+ * 4. A deadline of 0 must disable the mechanism entirely.
+ */
+import { fetchWithHeaderDeadline } from "../src/stream/stream.js";
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) throw new Error(`FAILED: ${message}`);
+}
+
+function hangForever(_url: string, init: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    init.signal?.addEventListener("abort", () => {
+      // Mirror fetch semantics: reject with the abort reason when provided.
+      const signal = init.signal as AbortSignal & { reason?: unknown };
+      reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+    });
+  });
+}
+
+function immediateResponse(_url: string, _init: RequestInit): Promise<Response> {
+  return Promise.resolve(new Response("ok"));
+}
+
+function slowBodyResponse(_url: string, _init: RequestInit): Promise<Response> {
+  // Headers resolve instantly; the body takes 120ms — longer than every deadline
+  // used in these tests.
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      await new Promise((res) => setTimeout(res, 30));
+      controller.enqueue(new TextEncoder().encode("chunk"));
+      controller.close();
+    },
+  });
+  return Promise.resolve(new Response(body));
+}
+
+async function main(): Promise<void> {
+  // 1. Tarpit: never resolves, deadline fires with the named error.
+  let sawTarpitError = false;
+  try {
+    await fetchWithHeaderDeadline("https://x", {}, undefined, 40, hangForever);
+    throw new Error("expected the tarpit fetch to reject");
+  } catch (error) {
+    sawTarpitError = error instanceof Error && /no response headers within 40ms/.test(error.message);
+  }
+  assert(sawTarpitError, "tarpit fetch should fail with the named header-deadline error");
+
+  // 2. Fast headers inside the deadline succeed.
+  const fast = await fetchWithHeaderDeadline("https://x", {}, undefined, 5000, immediateResponse);
+  assert(fast.ok, "fast fetch should succeed inside the deadline");
+
+  // 3. Slow body outlives the deadline but headers arrived: must complete.
+  const slow = await fetchWithHeaderDeadline("https://x", {}, undefined, 40, slowBodyResponse);
+  assert(slow.ok, "slow-body fetch must complete once headers arrived inside the deadline");
+
+  // 4. Deadline 0 disables the mechanism (hang would otherwise fire at any ms).
+  let sawDisablePath = false;
+  try {
+    await fetchWithHeaderDeadline("https://x", {}, undefined, 0, (_u, i) => {
+      sawDisablePath = i.signal === undefined;
+      return Promise.resolve(new Response("ok"));
+    });
+  } catch {
+    throw new Error("deadline 0 must not inject an abort signal");
+  }
+  assert(sawDisablePath, "deadline 0 should pass init through without a signal");
+
+  console.log("test-stream-header-deadline: all assertions passed");
+}
+
+await main();

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -863,7 +863,53 @@ function asToolCallArguments(args: Record<string, unknown> | undefined): ToolCal
   return (args ?? {}) as ToolCall["arguments"];
 }
 
+/** Default response-header deadline for streaming requests (see fetchWithHeaderDeadline). */
+const STREAM_HEADER_TIMEOUT_DEFAULT_MS = 180_000;
+
+/**
+ * Streaming header deadline in milliseconds, from ANTIGRAVITY_STREAM_HEADER_TIMEOUT_MS
+ * (or the legacy NOAGY_ prefix). 0 disables the deadline; invalid values fall back
+ * to the default.
+ */
+export function streamHeaderTimeoutMs(): number {
+  const raw = Number.parseInt(antigravityEnv("STREAM_HEADER_TIMEOUT_MS") ?? "", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : STREAM_HEADER_TIMEOUT_DEFAULT_MS;
+}
+
+/**
+ * Fetch with a response-header deadline. A server can accept a request on a warm
+ * keep-alive socket and then never send response headers; without a deadline that
+ * stall is unbounded. The timer covers only the header phase: once the fetch
+ * resolves (headers received) it is disarmed, so a long SSE body streams to
+ * completion regardless of duration.
+ *
+ * Exported with an injectable fetch for unit tests.
+ */
+export async function fetchWithHeaderDeadline(
+  url: string,
+  init: RequestInit,
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  fetchFn: (input: string, init: RequestInit) => Promise<Response> = antigravityFetch,
+): Promise<Response> {
+  if (timeoutMs <= 0) return fetchFn(url, init);
+  const controller = new AbortController();
+  const forward = () => controller.abort();
+  callerSignal?.addEventListener("abort", forward, { once: true });
+  const timer = setTimeout(
+    () => controller.abort(new Error(`no response headers within ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  try {
+    return await fetchFn(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+    callerSignal?.removeEventListener("abort", forward);
+  }
+}
+
 /** Exported for unit tests. */
+
 export async function streamResponse(
   response: Response,
   stream: AssistantMessageEventStream,
@@ -1108,14 +1154,15 @@ export function streamAntigravity(
 
           for (const endpoint of endpointCandidates()) {
             setLastEndpoint(endpoint);
-            response = await antigravityFetch(
+            response = await fetchWithHeaderDeadline(
               `${endpoint}/v1internal:streamGenerateContent?alt=sse`,
               {
                 method: "POST",
                 headers: requestHeaders,
                 body,
-                signal: opts.signal,
               },
+              opts.signal,
+              streamHeaderTimeoutMs(),
             );
             setLastStatus(response.status);
             if (response.ok) break;

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -865,6 +865,13 @@ function asToolCallArguments(args: Record<string, unknown> | undefined): ToolCal
 
 /** Default response-header deadline for streaming requests (see fetchWithHeaderDeadline). */
 const STREAM_HEADER_TIMEOUT_DEFAULT_MS = 180_000;
+/** Default mid-body stall deadline: abort when no SSE bytes arrive for this long. */
+const STREAM_STALL_TIMEOUT_DEFAULT_MS = 120_000;
+
+function envTimeoutMs(name: string, fallback: number): number {
+  const raw = Number.parseInt(antigravityEnv(name) ?? "", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
 
 /**
  * Streaming header deadline in milliseconds, from ANTIGRAVITY_STREAM_HEADER_TIMEOUT_MS
@@ -872,16 +879,62 @@ const STREAM_HEADER_TIMEOUT_DEFAULT_MS = 180_000;
  * to the default.
  */
 export function streamHeaderTimeoutMs(): number {
-  const raw = Number.parseInt(antigravityEnv("STREAM_HEADER_TIMEOUT_MS") ?? "", 10);
-  return Number.isFinite(raw) && raw >= 0 ? raw : STREAM_HEADER_TIMEOUT_DEFAULT_MS;
+  return envTimeoutMs("STREAM_HEADER_TIMEOUT_MS", STREAM_HEADER_TIMEOUT_DEFAULT_MS);
 }
 
 /**
- * Fetch with a response-header deadline. A server can accept a request on a warm
- * keep-alive socket and then never send response headers; without a deadline that
- * stall is unbounded. The timer covers only the header phase: once the fetch
- * resolves (headers received) it is disarmed, so a long SSE body streams to
- * completion regardless of duration.
+ * Mid-body stall deadline in milliseconds, from ANTIGRAVITY_STREAM_STALL_TIMEOUT_MS
+ * (legacy NOAGY_ prefix honored). 0 disables. A healthy SSE stream emits bytes
+ * continuously while generating, so a silent gap this long means the connection
+ * is dead even though headers arrived — abort with a named error rather than
+ * hanging until an external process timeout.
+ */
+export function streamStallTimeoutMs(): number {
+  return envTimeoutMs("STREAM_STALL_TIMEOUT_MS", STREAM_STALL_TIMEOUT_DEFAULT_MS);
+}
+
+function stallError(stallMs: number): Error {
+  return new Error(`stream stalled: no data for ${stallMs}ms`);
+}
+
+/**
+ * Guard a response body against mid-stream stalls: a TransformStream that
+ * resets an idle timer on every chunk and aborts the fetch controller when no
+ * bytes arrive within stallMs. pipeThrough keeps backpressure, so chunks are
+ * only read as the consumer pulls. The timer is cleared when the body ends
+ * (flush); it is also unref'd so an armed timer cannot keep the process alive.
+ */
+function attachStallWatchdog(response: Response, controller: AbortController, stallMs: number): Response {
+  if (stallMs <= 0 || !response.body) return response;
+  let timer = setTimeout(() => controller.abort(stallError(stallMs)), stallMs);
+  timer.unref?.();
+  const reset = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => controller.abort(stallError(stallMs)), stallMs);
+    timer.unref?.();
+  };
+  const guarded = response.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, enqueue) {
+        reset();
+        enqueue.enqueue(chunk);
+      },
+      flush() {
+        clearTimeout(timer);
+      },
+    }),
+  );
+  return new Response(guarded, response);
+}
+
+/**
+ * Fetch with a response-header deadline and a mid-body stall watchdog. A server
+ * can accept a request on a warm keep-alive socket and then never send response
+ * headers (header phase), or send headers and then go silent mid-body (stall
+ * phase); either way the request is aborted with a named error instead of
+ * hanging until an external process timeout. Long healthy responses are never
+ * cut: the header timer disarms once headers arrive, and the stall timer resets
+ * on every chunk, so only genuine silence aborts.
  *
  * Exported with an injectable fetch for unit tests.
  */
@@ -890,20 +943,24 @@ export async function fetchWithHeaderDeadline(
   init: RequestInit,
   callerSignal: AbortSignal | undefined,
   timeoutMs: number,
+  stallMs: number = 0,
   fetchFn: (input: string, init: RequestInit) => Promise<Response> = antigravityFetch,
 ): Promise<Response> {
-  if (timeoutMs <= 0) return fetchFn(url, init);
+  if (timeoutMs <= 0 && stallMs <= 0) return fetchFn(url, init);
   const controller = new AbortController();
   const forward = () => controller.abort();
   callerSignal?.addEventListener("abort", forward, { once: true });
-  const timer = setTimeout(
-    () => controller.abort(new Error(`no response headers within ${timeoutMs}ms`)),
-    timeoutMs,
-  );
+  const timer = timeoutMs > 0
+    ? setTimeout(
+        () => controller.abort(new Error(`no response headers within ${timeoutMs}ms`)),
+        timeoutMs,
+      )
+    : undefined;
   try {
-    return await fetchFn(url, { ...init, signal: controller.signal });
+    const response = await fetchFn(url, { ...init, signal: controller.signal });
+    return attachStallWatchdog(response, controller, stallMs);
   } finally {
-    clearTimeout(timer);
+    if (timer) clearTimeout(timer);
     callerSignal?.removeEventListener("abort", forward);
   }
 }
@@ -1163,6 +1220,7 @@ export function streamAntigravity(
               },
               opts.signal,
               streamHeaderTimeoutMs(),
+              streamStallTimeoutMs(),
             );
             setLastStatus(response.status);
             if (response.ok) break;


### PR DESCRIPTION
## Problem

A server can accept a streaming request on a warm keep-alive socket and then never send response headers. The existing connect timeout (`CONNECT_TIMEOUT_MS` = 10s) does not cover this — the physical connection already succeeded — so the stall is unbounded and only an external process-level timeout ends it. Discovery calls already carry `AbortSignal.timeout`; the streaming path is the only unbounded one.

## Solution

`fetchWithHeaderDeadline()` wraps the `streamGenerateContent` fetch in a **header-phase** deadline: a timer that aborts the request if the fetch (i.e. response headers) has not resolved within the window, and **disarms the moment it does** — so a long SSE body always streams to completion regardless of duration. A bare `AbortSignal.timeout` on the fetch would incorrectly cut off any response whose total stream time exceeds the window; that is why the timer is cleared on resolution.

- Deadline from `ANTIGRAVITY_STREAM_HEADER_TIMEOUT_MS` (legacy `NOAGY_` prefix honored via `antigravityEnv`), default **180000ms**, `0` disables.
- Caller's `opts.signal` is forwarded (chained abort), preserving existing cancellation behavior.
- Helper takes an injectable fetch fn for unit tests.

## Tests

`scripts/test-stream-header-deadline.ts` (wired into the `test` chain):
1. Never-responding fetch fails fast with the named error `no response headers within 40ms`
2. Fast fetch inside the deadline succeeds
3. Fast headers + slow body (body outlives deadline) completes — proves header-phase-only semantics
4. Deadline 0 passes init through with no injected signal

Full `bun run test` chain passes; `eslint src` clean; typecheck shows the same 2 pre-existing errors as pristine main (none introduced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable deadline for receiving response headers during streaming requests.
  * Added detection for stalled response bodies during streaming.
  * Supports disabling or configuring header and body-stall deadlines through environment settings.
  * Streaming continues normally after headers are received, even if response chunks arrive slowly.

* **Bug Fixes**
  * Streaming requests that do not receive headers within the deadline now fail with a timeout error.
  * Streaming requests that stop receiving data mid-response now fail with a stall error instead of hanging indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->