### PR TITLE
fix(stream): omit toolConfig on default auto mode aligned with agy CLI wire fingerprint

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -6,7 +6,7 @@ import {
   stableProjectId,
 } from "../src/client/index.js";
 import { getLastDiagnostics, resetDiagnosticsForTests } from "../src/diagnostics/index.js";
-import { StopReason } from "../src/types/enums.js";
+import { GeminiToolCallingMode, StopReason, ToolChoice } from "../src/types/enums.js";
 import {
   ANTIGRAVITY_MODELS,
   getMaxOutputTokens,
@@ -1054,6 +1054,129 @@ try {
   if (savedNoagyUserAgent !== undefined) process.env.NOAGY_USER_AGENT = savedNoagyUserAgent;
   else delete process.env.NOAGY_USER_AGENT;
 }
+
+// Wire fingerprint: toolConfig omission on default (auto) for all models (pure agy CLI)
+const dummyToolsContext: Context = {
+  ...dummyContext,
+  tools: [
+    {
+      name: "read_file",
+      description: "Read a file",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+    } as Tool,
+  ],
+};
+
+// 1. Gemini with tools: tools present, toolConfig undefined
+const geminiWithTools = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  {},
+  "gemini-3.7-flash-high",
+);
+assert.ok(geminiWithTools.request.tools);
+assert.equal(geminiWithTools.request.toolConfig, undefined);
+
+// 2. Claude with tools: tools present, toolConfig undefined
+const claudeWithTools = buildRequest(
+  model,
+  dummyToolsContext,
+  "test-proj",
+  {},
+  "claude-sonnet-4-6",
+);
+assert.ok(claudeWithTools.request.tools);
+assert.equal(claudeWithTools.request.toolConfig, undefined);
+
+// 3. Claude without tools: toolConfig undefined (no legacy VALIDATED injection)
+const claudeNoTools = buildRequest(
+  model,
+  dummyContext,
+  "test-proj",
+  {},
+  "claude-sonnet-4-6",
+);
+assert.equal(claudeNoTools.request.tools, undefined);
+assert.equal(claudeNoTools.request.toolConfig, undefined);
+
+// 4. GPT-OSS with tools: tools present, toolConfig undefined
+const gptOssModel = { ...model, id: "gpt-oss-120b", maxTokens: 32768 };
+const gptOssWithTools = buildRequest(
+  gptOssModel,
+  dummyToolsContext,
+  "test-proj",
+  {},
+  "gpt-oss-120b-medium",
+);
+assert.ok(gptOssWithTools.request.tools);
+assert.equal(gptOssWithTools.request.toolConfig, undefined);
+
+// 5. Explicit toolChoice: "auto" -> toolConfig undefined
+const autoReq = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: ToolChoice.Auto },
+  "gemini-3.7-flash-high",
+);
+assert.equal(autoReq.request.toolConfig, undefined);
+
+// 6. Explicit toolChoice: "none" -> toolConfig mode NONE
+const noneReq = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: ToolChoice.None },
+  "gemini-3.7-flash-high",
+);
+assert.deepEqual(noneReq.request.toolConfig, {
+  functionCallingConfig: { mode: GeminiToolCallingMode.None },
+});
+
+// 7. Explicit toolChoice: "any" / "required" -> toolConfig mode ANY
+const anyReq = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: ToolChoice.Any },
+  "gemini-3.7-flash-high",
+);
+assert.deepEqual(anyReq.request.toolConfig, {
+  functionCallingConfig: { mode: GeminiToolCallingMode.Any },
+});
+
+const reqChoice = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: ToolChoice.Required },
+  "gemini-3.7-flash-high",
+);
+assert.deepEqual(reqChoice.request.toolConfig, {
+  functionCallingConfig: { mode: GeminiToolCallingMode.Any },
+});
+
+// 8. String literals compatibility (Pi SimpleStreamOptions)
+const stringAutoReq = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: "auto" },
+  "gemini-3.7-flash-high",
+);
+assert.equal(stringAutoReq.request.toolConfig, undefined);
+
+const stringNoneReq = buildRequest(
+  flash37Model,
+  dummyToolsContext,
+  "test-proj",
+  { toolChoice: "none" },
+  "gemini-3.7-flash-high",
+);
+assert.deepEqual(stringNoneReq.request.toolConfig, {
+  functionCallingConfig: { mode: GeminiToolCallingMode.None },
+});
 
 console.log(
   `model routing: ${routeCases.length} cases, tool schema, errors, project ids, token clamping, and message conversion passed`,

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -746,17 +746,12 @@ export function buildRequest(
   const tools = convertTools(context.tools, isClaude || model.id.startsWith("gpt-oss-"));
   if (tools) {
     request.tools = tools;
+  }
+  if (options.toolChoice && options.toolChoice !== ToolChoice.Auto) {
     request.toolConfig = {
       functionCallingConfig: {
-        mode:
-          options.toolChoice && options.toolChoice !== ToolChoice.Auto
-            ? mapToolChoiceMode(options.toolChoice)
-            : GeminiToolCallingMode.Validated,
+        mode: mapToolChoiceMode(options.toolChoice),
       },
-    };
-  } else if (isClaude) {
-    request.toolConfig = {
-      functionCallingConfig: { mode: GeminiToolCallingMode.Validated },
     };
   }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -50,8 +50,8 @@ export type AntigravityRouting = {
 export const ANTIGRAVITY_API = "antigravity-api" as const;
 export type AntigravityApi = typeof ANTIGRAVITY_API;
 
-export type AntigravityStreamOptions = SimpleStreamOptions & {
-  toolChoice?: ToolChoice;
+export type AntigravityStreamOptions = Omit<SimpleStreamOptions, "toolChoice"> & {
+  toolChoice?: ToolChoice | `${ToolChoice}`;
 };
 
 export type GeminiTextPart = { text: string; thoughtSignature?: string };


### PR DESCRIPTION
# Pull request

## Summary

Aligns `toolConfig` behavior with the official Antigravity CLI (`agy` v1.1.23) wire format by completely omitting `request.toolConfig` on default tool calling (`auto` mode), and only populating it when `toolChoice` is explicitly set (`none`, `any`, `required`).

### Background & Motivation
In `pi-antigravity`, whenever tools were declared, `request.toolConfig = { functionCallingConfig: { mode: "VALIDATED" } }` was forcibly injected into the payload for all models. Furthermore, an `else if (isClaude)` branch forcibly injected `mode: "VALIDATED"` even when Claude had zero tools.

However, full network inspection across the pure official `agy` CLI (v1.1.23, CL: 974125021) reveals that:
1. **`request.toolConfig` is completely omitted (`undefined`)** across **all models** (Gemini 3.8/3.7/3.1, Claude Sonnet/Opus, GPT-OSS) during default tool calling (`auto` mode), even when 17 tools are passed in `request.tools`.
2. The Google Cloud Code Assist backend natively defaults to `AUTO` when `toolConfig` is absent, and the official CLI never sends `VALIDATED`.
3. Forcibly sending `VALIDATED` leaks a legacy VS Code extension (Cloud Shell Editor) fingerprint that immediately distinguishes unofficial clients from pure `agy` CLI traffic.

### Changes
1. **Omit `toolConfig` on Default Auto Mode (`src/stream/stream.ts`)**:
   - `request.tools = tools;` is set as usual.
   - `request.toolConfig` is only constructed if `options.toolChoice && options.toolChoice !== ToolChoice.Auto`.
   - Removed legacy `else if (isClaude)` block that forcibly injected `VALIDATED` on Claude with zero tools.
2. **Options Typing Compatibility (`src/types/types.ts`)**:
   - Extended `AntigravityStreamOptions.toolChoice` with `${ToolChoice}`:
     ```typescript
     export type AntigravityStreamOptions = Omit<SimpleStreamOptions, "toolChoice"> & {
       toolChoice?: ToolChoice | `${ToolChoice}`;
     };
     ```
   - Preserves canonical `export enum ToolChoice` in `src/types/enums.ts` while cleanly accepting string literals (`"auto" | "none"`) from Pi's `@earendil-works/pi-ai` `SimpleStreamOptions`.
3. **Tests Updated (`scripts/test-model-routing.ts`)**:
   - Added 8 comprehensive wire fingerprint assertions:
     - Gemini with tools -> `toolConfig === undefined`
     - Claude with tools -> `toolConfig === undefined`
     - Claude without tools -> `toolConfig === undefined` (no legacy `VALIDATED` injection)
     - GPT-OSS with tools -> `toolConfig === undefined`
     - Explicit `toolChoice: ToolChoice.Auto` / `"auto"` -> `toolConfig === undefined`
     - Explicit `toolChoice: ToolChoice.None` / `"none"` -> `mode: "NONE"`
     - Explicit `toolChoice: ToolChoice.Any` / `ToolChoice.Required` -> `mode: "ANY"`

---

## Wire Fingerprint Verification 

An end-to-end network intercept was conducted to capture raw wire traffic emitted by the pure official `agy` CLI (v1.1.23, CL: 974125021) across all supported models.

### Results Matrix (`streamGenerateContent`)

| # | Model | Tools Declared on Wire (`request.tools`) | `request.toolConfig` on Wire | Backend Behavior | Verdict |
|---|---|:---:|:---:|:---:|:---:|
| 1 | `gemini-3.8-flash-high` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 2 | `gemini-3.8-flash-medium` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 3 | `gemini-3.8-flash-low` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 4 | `gemini-3.7-flash-high` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 5 | `gemini-3.7-flash-medium` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 6 | `gemini-3.7-flash-low` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 7 | `gemini-3.1-pro-high` (`gemini-pro-agent`) | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 8 | `gemini-3.1-pro-low` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 9 | `claude-sonnet-4-6` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 10 | `claude-opus-4-6-thinking` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |
| 11 | `gpt-oss-120b-medium` | **17 tools** | **`null` (omitted)** | `AUTO` | ✅ MATCH |

---

## Validation

- [x] Full packet capture verifying `toolConfig` omission across all models on `agy` CLI v1.1.23
- [x] Typecheck clean: `tsc --noEmit`
- [x] Linter clean: `eslint src`
- [x] Formatter clean: `prettier --check src scripts`
- [x] Security check clean: `security-check: ok`
- [x] Unit & regression tests clean: `bun scripts/test-model-routing.ts` (all 35 cases + 8 new wire fingerprint assertions passed)

## Security

- [x] No credentials, tokens, secrets, or private account data are included
- [x] Security implications have been considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tool configuration is no longer sent by default when no explicit tool choice is provided.
  - Requests without tools no longer include unnecessary tool-related settings.
  - Explicit tool choices now consistently control tool-calling behavior across supported models.
  - “Auto,” “none,” “any,” and “required” choices now produce the expected tool-calling modes.

- **Improvements**
  - Tool choices can be provided using either supported enum values or equivalent string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->