### PR TITLE
feat(stream): align request envelope labels, integer thinkingBudget, and dynamic model_enum with agy CLI wire traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Use `/antigravity.models` to see live availability and quota for your account. R
 
 Antigravity / Cloud Code Assist exposes a multi-provider catalog. Depending on your account, its Google-authenticated API can advertise Google Gemini models alongside Claude models served through Anthropic Vertex and GPT-OSS served through OpenAI Vertex. This extension intentionally exposes those advertised Claude and GPT-OSS models through the single `antigravity` provider; they are not separate Pi providers and do not use a separate Anthropic or OpenAI login.
 
-The backend's display labels do not always match its runtime IDs. For example, `gemini-3.5-flash-extra-low`, `gemini-3.5-flash-low`, and `gemini-3-flash-agent` can be displayed as Gemini 3.5 Flash Low, Medium, and High. Gemini 3.8, 3.7, and 3.6 Flash use per-effort runtime IDs and send `thinkingLevel`; Gemini 3.5 Flash and 3.1 Pro send `thinkingBudget`.
+The backend's display labels do not always match its runtime IDs. For example, `gemini-3.5-flash-extra-low`, `gemini-3.5-flash-low`, and `gemini-3-flash-agent` can be displayed as Gemini 3.5 Flash Low, Medium, and High. All supported models send integer `thinkingBudget` (Gemini 3.8/3.7/3.6: -1/4000/1000/0, Gemini 3.5: 10000/4000/1000/0, Gemini 3.1 Pro: 10001/1001/0, Claude: 1024/0, GPT-OSS: 8192/0) matching the official Antigravity CLI wire format.
 
 <!-- prettier-ignore -->
 | Public model ID | Input | Thinking levels shown | Max output tokens | Request routing |

--- a/scripts/smoke-all-models.mjs
+++ b/scripts/smoke-all-models.mjs
@@ -132,7 +132,7 @@ async function smokeOne(publicId) {
     for (let i = 0; i < candidates.length; i++) {
       runtimeModel = candidates[i];
       const isClaude = publicId.startsWith("claude-") || runtimeModel.startsWith("claude-");
-      const generationConfig: Record<string, unknown> = { maxOutputTokens: 256 };
+      const generationConfig = { maxOutputTokens: 256 };
       if (
         publicId === "gemini-3.8-flash" ||
         publicId === "gemini-3.7-flash" ||
@@ -160,10 +160,7 @@ async function smokeOne(publicId) {
         requestId: utils.nowRequestId(),
       };
 
-      const headers = {
-        ...client.antigravityHeaders(refreshed.access),
-        ...(isClaude ? { "anthropic-beta": "interleaved-thinking-2025-05-14" } : {}),
-      };
+      const headers = client.antigravityHeaders(refreshed.access);
 
       for (const ep of client.endpointCandidates()) {
         usedEndpoint = ep;

--- a/scripts/smoke-all-models.mjs
+++ b/scripts/smoke-all-models.mjs
@@ -132,21 +132,10 @@ async function smokeOne(publicId) {
     for (let i = 0; i < candidates.length; i++) {
       runtimeModel = candidates[i];
       const isClaude = publicId.startsWith("claude-") || runtimeModel.startsWith("claude-");
-      const generationConfig: Record<string, unknown> = { maxOutputTokens: 256 };
-      if (
-        publicId === "gemini-3.8-flash" ||
-        publicId === "gemini-3.7-flash" ||
-        publicId === "gemini-3.6-flash"
-      ) {
-        generationConfig.thinkingConfig = {
-          includeThoughts: true,
-          thinkingLevel:
-            EFFORT === "high" || EFFORT === "xhigh"
-              ? "HIGH"
-              : EFFORT === "medium"
-                ? "MEDIUM"
-                : "LOW",
-        };
+      const generationConfig = { maxOutputTokens: 256 };
+      const thinkingConfig = models.getThinkingConfig(publicId, EFFORT);
+      if (thinkingConfig) {
+        generationConfig.thinkingConfig = thinkingConfig;
       }
       const body = {
         project: projectId,

--- a/scripts/smoke-sonnet.mjs
+++ b/scripts/smoke-sonnet.mjs
@@ -31,10 +31,7 @@ const body = {
 const endpoint = client.endpointCandidates()[0];
 const res = await fetch(`${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
   method: "POST",
-  headers: {
-    ...client.antigravityHeaders(refreshed.access),
-    "anthropic-beta": "interleaved-thinking-2025-05-14",
-  },
+  headers: client.antigravityHeaders(refreshed.access),
   body: JSON.stringify(body),
 });
 console.log("status=", res.status, "endpoint=", endpoint);

--- a/scripts/smoke-tool-schema.ts
+++ b/scripts/smoke-tool-schema.ts
@@ -71,12 +71,7 @@ for (const { label, modelId, effort } of modelCases) {
     `${endpointCandidates()[0]}/v1internal:streamGenerateContent?alt=sse`,
     {
       method: "POST",
-      headers: {
-        ...antigravityHeaders(refreshed.access),
-        ...(modelId.startsWith("claude-")
-          ? { "anthropic-beta": "interleaved-thinking-2025-05-14" }
-          : {}),
-      },
+      headers: antigravityHeaders(refreshed.access),
       body: JSON.stringify({
         project: projectId,
         model: runtimeModel,

--- a/scripts/test-model-discovery.ts
+++ b/scripts/test-model-discovery.ts
@@ -154,9 +154,9 @@ assert.equal(
 assert.equal(getAntigravityRequestModelId("claude-opus-4-6", "high"), "claude-opus-4-6-thinking");
 assert.equal(getAntigravityRequestModelId("gpt-oss-120b", "medium"), "gpt-oss-120b-medium");
 assert.equal(
-  getThinkingConfig("gemini-3.8-flash", "medium")?.thinkingLevel,
-  "MEDIUM",
-  "new Gemini families send thinkingLevel",
+  getThinkingConfig("gemini-3.8-flash", "medium")?.thinkingBudget,
+  4000,
+  "Gemini families send thinkingBudget",
 );
 assert.equal(getThinkingConfig("gemini-3.5-flash", "medium")?.thinkingBudget, 4000);
 assert.equal(
@@ -164,11 +164,22 @@ assert.equal(
   false,
   "reasoning=off disables Gemini thinking",
 );
-assert.equal(getThinkingConfig("gemini-3.7-flash", "off")?.thinkingLevel, undefined);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "off")?.thinkingBudget, 0);
 assert.equal(getThinkingConfig("gemini-3.6-flash", undefined)?.includeThoughts, false);
+assert.equal(getThinkingConfig("gemini-3.6-flash", undefined)?.thinkingBudget, 0);
 assert.equal(getThinkingConfig("gemini-3.8-flash", "off")?.includeThoughts, false);
+assert.equal(getThinkingConfig("gemini-3.8-flash", "off")?.thinkingBudget, 0);
 assert.equal(getThinkingConfig("gemini-3.7-flash", "medium")?.includeThoughts, true);
-assert.equal(getThinkingConfig("gemini-3.7-flash", "medium")?.thinkingLevel, "MEDIUM");
+assert.equal(getThinkingConfig("gemini-3.7-flash", "medium")?.thinkingBudget, 4000);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "high")?.thinkingBudget, -1);
+assert.equal(getThinkingConfig("gemini-3.7-flash", "low")?.thinkingBudget, 1000);
+
+// Claude and GPT-OSS thinking budgets
+assert.equal(getThinkingConfig("claude-sonnet-4-6", "high")?.thinkingBudget, 1024);
+assert.equal(getThinkingConfig("claude-opus-4-6", "high")?.thinkingBudget, 1024);
+assert.equal(getThinkingConfig("claude-sonnet-4-6", "off")?.thinkingBudget, 0);
+assert.equal(getThinkingConfig("gpt-oss-120b", "medium")?.thinkingBudget, 8192);
+assert.equal(getThinkingConfig("gpt-oss-120b", "off")?.thinkingBudget, 0);
 
 const mergedDefaultOnly = mergeAvailableModelsResults([
   {

--- a/scripts/test-model-discovery.ts
+++ b/scripts/test-model-discovery.ts
@@ -1,18 +1,22 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mergeAvailableModelsResults } from "../src/client/index.js";
+import { antigravityHeaders, mergeAvailableModelsResults } from "../src/client/index.js";
 import type { ModelInfoRaw } from "../src/types/types.js";
 import {
   ANTIGRAVITY_MODELS,
   ANTIGRAVITY_ROUTING,
   applyAntigravityCatalog,
   buildAntigravityCatalog,
+  clearModelEnumCache,
   getAntigravityRequestModelId,
   getFallbackRuntimeModel,
+  getModelEnum,
   getThinkingConfig,
   humanizePublicId,
   readCatalogCache,
+  registerDiscoveredModelEnums,
+  registerModelEnum,
   resetAntigravityCatalogForTests,
   resolvedCatalog,
   setCatalogCachePathForTests,
@@ -30,6 +34,9 @@ function fail(message: string): never {
 const assert = {
   equal(actual: unknown, expected: unknown, message?: string) {
     if (actual !== expected) fail(message ?? `expected ${String(expected)}, got ${String(actual)}`);
+  },
+  notEqual(actual: unknown, expected: unknown, message?: string) {
+    if (actual === expected) fail(message ?? `expected values not to be equal: ${String(actual)}`);
   },
   ok(value: unknown, message?: string) {
     if (!value) fail(message ?? "expected a truthy value");
@@ -449,6 +456,50 @@ try {
   setCatalogCachePathForTests(undefined);
   rmSync(dirError, { recursive: true, force: true });
 }
+// Wire fingerprint headers: Accept: application/json must not be injected for model discovery
+const defaultHeaders = antigravityHeaders("test-token");
+assert.notEqual(
+  defaultHeaders.Accept,
+  "application/json",
+  "Accept: application/json must not be sent on discovery requests",
+);
+
+// Static fallback model_enum resolution
+clearModelEnumCache();
+assert.equal(getModelEnum("gemini-3.8-flash-high"), "MODEL_PLACEHOLDER_M318");
+assert.equal(getModelEnum("gemini-3.7-flash-high"), "MODEL_PLACEHOLDER_M298");
+assert.equal(getModelEnum("gemini-3.6-flash-high"), "MODEL_PLACEHOLDER_M71");
+assert.equal(getModelEnum("claude-sonnet-4-6"), "MODEL_PLACEHOLDER_M35");
+assert.equal(getModelEnum("gpt-oss-120b-medium"), "MODEL_OPENAI_GPT_OSS_120B_MEDIUM");
+
+// Dynamic model_enum registration and cache precedence
+registerModelEnum("custom-future-model", "MODEL_PLACEHOLDER_M999");
+assert.equal(getModelEnum("custom-future-model"), "MODEL_PLACEHOLDER_M999");
+registerModelEnum("gemini-3.8-flash-high", "MODEL_OVERRIDE_DYNAMIC");
+assert.equal(getModelEnum("gemini-3.8-flash-high"), "MODEL_OVERRIDE_DYNAMIC", "dynamic cache overrides static");
+
+// Batch registration from catalog discovery
+registerDiscoveredModelEnums({
+  "gemini-4.0-flash": { model: "MODEL_PLACEHOLDER_M400" },
+});
+assert.equal(getModelEnum("gemini-4.0-flash"), "MODEL_PLACEHOLDER_M400");
+
+// mergeAvailableModelsResults registers model_enum dynamically
+mergeAvailableModelsResults([
+  {
+    endpoint: "https://daily-cloudcode-pa.googleapis.com",
+    status: 200,
+    data: {
+      models: {
+        "catalog-dynamic-model": { model: "MODEL_CATALOG_DISCOVERED" },
+      },
+    },
+  },
+]);
+assert.equal(getModelEnum("catalog-dynamic-model"), "MODEL_CATALOG_DISCOVERED");
+
+clearModelEnumCache();
+assert.equal(getModelEnum("gemini-3.8-flash-high"), "MODEL_PLACEHOLDER_M318", "clearModelEnumCache restores static");
 
 console.log(
   "model discovery: grouping, overrides, empty/failure fallback, cache replace-on-success, thinking config, and refresh TTL passed",

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -20,6 +20,10 @@ import {
   friendlyAntigravityError,
   mapStopReason,
 } from "../src/stream/index.js";
+import {
+  antigravityRequestEnvelope,
+  clearSessionTrajectoryMap,
+} from "../src/utils/util.js";
 
 function fail(message: string): never {
   throw new Error(message);
@@ -1054,6 +1058,177 @@ try {
   if (savedNoagyUserAgent !== undefined) process.env.NOAGY_USER_AGENT = savedNoagyUserAgent;
   else delete process.env.NOAGY_USER_AGENT;
 }
+// Wire fingerprint: Envelope & labels normalization (PR 4)
+// 1. antigravityRequestEnvelope backwards compatibility and options support
+const envDefault = antigravityRequestEnvelope("gemini-3.7-flash-high", false);
+assert.equal(envDefault.labels.last_step_index, "0");
+assert.equal(envDefault.labels.request_id, `${envDefault.labels.trajectory_id}-0`);
+assert.equal(envDefault.labels.used_claude, "false");
+assert.equal(envDefault.labels.used_claude_conservative, "false");
+assert.equal(envDefault.labels.used_non_gemini_model, "false");
+assert.equal(envDefault.labels.model_enum, "MODEL_PLACEHOLDER_M298");
+assert.match(envDefault.requestId, /^agent\/[0-9a-f-]+\/\d+\/[0-9a-f-]+\/1$/);
+
+const envClaude = antigravityRequestEnvelope("claude-sonnet-4-6", true);
+assert.equal(envClaude.labels.last_step_index, "0");
+assert.equal(envClaude.labels.used_claude, "true");
+assert.equal(envClaude.labels.used_claude_conservative, "true");
+assert.equal(envClaude.labels.used_non_gemini_model, "true");
+assert.equal(envClaude.labels.model_enum, "MODEL_PLACEHOLDER_M35");
+
+const envMultiTurn = antigravityRequestEnvelope("gpt-oss-120b-medium", {
+  isNonGemini: true,
+  step: 3,
+});
+assert.equal(envMultiTurn.labels.last_step_index, "2");
+assert.equal(envMultiTurn.labels.request_id, `${envMultiTurn.labels.trajectory_id}-2`);
+assert.equal(envMultiTurn.labels.used_claude, "false");
+assert.equal(envMultiTurn.labels.used_non_gemini_model, "true");
+assert.equal(envMultiTurn.labels.model_enum, "MODEL_OPENAI_GPT_OSS_120B_MEDIUM");
+assert.match(envMultiTurn.requestId, /^agent\/[0-9a-f-]+\/\d+\/[0-9a-f-]+\/3$/);
+
+// 2. buildRequest wire labels across models
+const claudeSonnetModel = ANTIGRAVITY_MODELS.find((m) => m.id === "claude-sonnet-4-6")!;
+const claudeOpusModel = ANTIGRAVITY_MODELS.find((m) => m.id === "claude-opus-4-6")!;
+const gptOssModel = ANTIGRAVITY_MODELS.find((m) => m.id === "gpt-oss-120b")!;
+const pro31Model = ANTIGRAVITY_MODELS.find((m) => m.id === "gemini-3.1-pro")!;
+
+const reqFlash38 = buildRequest(
+  ANTIGRAVITY_MODELS.find((m) => m.id === "gemini-3.8-flash")!,
+  dummyContext,
+  "test-proj",
+  {},
+  "gemini-3.8-flash-high",
+);
+assert.equal(reqFlash38.request.labels?.last_step_index, "0");
+assert.equal(reqFlash38.request.labels?.request_id, `${reqFlash38.request.labels?.trajectory_id}-0`);
+assert.equal(reqFlash38.request.labels?.used_claude, "false");
+assert.equal(reqFlash38.request.labels?.used_claude_conservative, "false");
+assert.equal(reqFlash38.request.labels?.used_non_gemini_model, "false");
+assert.equal(reqFlash38.request.labels?.model_enum, "MODEL_PLACEHOLDER_M318");
+assert.match(reqFlash38.requestId, /\/1$/);
+
+const reqFlash36 = buildRequest(
+  ANTIGRAVITY_MODELS.find((m) => m.id === "gemini-3.6-flash")!,
+  dummyContext,
+  "test-proj",
+  {},
+  "gemini-3.6-flash-high",
+);
+assert.equal(reqFlash36.request.labels?.model_enum, "MODEL_PLACEHOLDER_M71");
+assert.equal(reqFlash36.request.labels?.used_non_gemini_model, "false");
+
+const reqPro = buildRequest(pro31Model, dummyContext, "test-proj", {}, "gemini-pro-agent");
+assert.equal(reqPro.request.labels?.model_enum, "MODEL_PLACEHOLDER_M16");
+assert.equal(reqPro.request.labels?.used_claude, "false");
+assert.equal(reqPro.request.labels?.used_non_gemini_model, "false");
+
+const reqSonnet = buildRequest(claudeSonnetModel, dummyContext, "test-proj", {}, "claude-sonnet-4-6");
+assert.equal(reqSonnet.request.labels?.used_claude, "true");
+assert.equal(reqSonnet.request.labels?.used_claude_conservative, "true");
+assert.equal(reqSonnet.request.labels?.used_non_gemini_model, "true");
+assert.equal(reqSonnet.request.labels?.model_enum, "MODEL_PLACEHOLDER_M35");
+
+const reqOpus = buildRequest(claudeOpusModel, dummyContext, "test-proj", {}, "claude-opus-4-6-thinking");
+assert.equal(reqOpus.request.labels?.used_claude, "true");
+assert.equal(reqOpus.request.labels?.used_non_gemini_model, "true");
+assert.equal(reqOpus.request.labels?.model_enum, "MODEL_PLACEHOLDER_M26");
+
+const reqGptOss = buildRequest(gptOssModel, dummyContext, "test-proj", {}, "gpt-oss-120b-medium");
+assert.equal(reqGptOss.request.labels?.used_claude, "false");
+assert.equal(reqGptOss.request.labels?.used_claude_conservative, "false");
+assert.equal(reqGptOss.request.labels?.used_non_gemini_model, "true");
+assert.equal(reqGptOss.request.labels?.model_enum, "MODEL_OPENAI_GPT_OSS_120B_MEDIUM");
+
+// 3. Multi-turn step calculation and tool call request_id sequence
+const baseTime = 1700000000000;
+const turn1Context: Context = {
+  messages: [{ role: "user", content: "read file", timestamp: baseTime }],
+};
+
+// Turn 1, call 1: initial user prompt (0 prior assistant turns -> request_id: <traj>-0)
+const reqTurn1 = buildRequest(flash37Model, turn1Context, "test-proj", {}, "gemini-3.7-flash-low");
+assert.equal(reqTurn1.request.labels?.last_step_index, "0");
+assert.equal(reqTurn1.request.labels?.request_id, `${reqTurn1.request.labels?.trajectory_id}-0`);
+assert.match(reqTurn1.requestId, /\/1$/);
+
+// Turn 1, call 2: tool execution result follows (1 assistant toolCall + 1 toolResult in context -> request_id: <traj>-1)
+const turn1ToolContext: Context = {
+  messages: [
+    { role: "user", content: "read file", timestamp: baseTime },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "read_file",
+          arguments: { path: "a.txt" },
+          thoughtSignature: "dGVzdC1zaWduYXR1cmUtMTIzNDU2",
+        },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: zeroUsage,
+      stopReason: "stop",
+      timestamp: baseTime + 1000,
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read_file",
+      content: [{ type: "text", text: "file content" }],
+      isError: false,
+      timestamp: baseTime + 2000,
+    },
+  ],
+};
+const reqTurn1Tool = buildRequest(flash37Model, turn1ToolContext, "test-proj", {}, "gemini-3.7-flash-low");
+assert.equal(reqTurn1Tool.request.labels?.last_step_index, "2");
+assert.equal(reqTurn1Tool.request.labels?.request_id, `${reqTurn1Tool.request.labels?.trajectory_id}-1`);
+assert.match(reqTurn1Tool.requestId, /\/3$/);
+assert.equal(
+  reqTurn1Tool.request.labels?.trajectory_id,
+  reqTurn1.request.labels?.trajectory_id,
+  "tool execution loop preserves same trajectory_id",
+);
+
+// Turn 2, call 3: user follow-up prompt (2 prior assistant turns -> request_id: <traj>-2)
+const turn2Context: Context = {
+  messages: [
+    ...turn1ToolContext.messages,
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "done reading" }],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: zeroUsage,
+      stopReason: "stop",
+      timestamp: baseTime + 3000,
+    },
+    { role: "user", content: "summarize it", timestamp: baseTime + 4000 },
+  ],
+};
+const reqTurn2 = buildRequest(flash37Model, turn2Context, "test-proj", {}, "gemini-3.7-flash-low");
+assert.equal(reqTurn2.request.labels?.last_step_index, "4");
+assert.equal(reqTurn2.request.labels?.request_id, `${reqTurn2.request.labels?.trajectory_id}-2`);
+assert.match(reqTurn2.requestId, /\/5$/);
+assert.equal(
+  reqTurn2.request.labels?.trajectory_id,
+  reqTurn1.request.labels?.trajectory_id,
+  "turn 2 preserves same trajectory_id",
+);
+
+// 4. Session restart resilience: clearing in-memory cache restores identical deterministic trajectory_id
+clearSessionTrajectoryMap();
+const reqTurn2Restarted = buildRequest(flash37Model, turn2Context, "test-proj", {}, "gemini-3.7-flash-low");
+assert.equal(
+  reqTurn2Restarted.request.labels?.trajectory_id,
+  reqTurn1.request.labels?.trajectory_id,
+  "deterministic seed restores identical trajectory_id across process restarts",
+);
 
 console.log(
   `model routing: ${routeCases.length} cases, tool schema, errors, project ids, token clamping, and message conversion passed`,

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -774,21 +774,22 @@ const reqD = buildRequest(
 );
 assert.equal(reqD.request.generationConfig?.maxOutputTokens, 65535);
 
-// Case E: Gemini 3.8/3.7/3.6 send thinkingLevel; 3.5 sends thinkingBudget.
+// Case E: Gemini models send thinkingBudget (high: -1, medium: 4000, low: 1000, off: 0)
 const flash38Model = { ...model, id: "gemini-3.8-flash", maxTokens: 65536 };
-for (const [reasoning, thinkingLevel, runtime] of [
-  ["low", "LOW", "gemini-3.8-flash-low"],
-  ["medium", "MEDIUM", "gemini-3.8-flash-medium"],
-  ["high", "HIGH", "gemini-3.8-flash-high"],
+for (const [reasoning, thinkingBudget, runtime] of [
+  ["low", 1000, "gemini-3.8-flash-low"],
+  ["medium", 4000, "gemini-3.8-flash-medium"],
+  ["high", -1, "gemini-3.8-flash-high"],
 ] as const) {
   const request = buildRequest(flash38Model, dummyContext, "test-proj", { reasoning }, runtime);
-  assert.equal(request.request.generationConfig?.thinkingConfig?.thinkingLevel, thinkingLevel);
+  assert.equal(request.request.generationConfig?.thinkingConfig?.thinkingBudget, thinkingBudget);
   assert.equal(request.request.generationConfig?.thinkingConfig?.includeThoughts, true);
 }
 
 const flash37Model = { ...model, id: "gemini-3.7-flash", maxTokens: 65536 };
 const flash37 = buildRequest(flash37Model, dummyContext, "test-proj", { reasoning: "high" }, "gemini-3.7-flash-high");
-assert.equal(flash37.request.generationConfig?.thinkingConfig?.thinkingLevel, "HIGH");
+assert.equal(flash37.request.generationConfig?.thinkingConfig?.thinkingBudget, -1);
+assert.equal(flash37.request.generationConfig?.thinkingConfig?.includeThoughts, true);
 
 const flash36 = buildRequest(
   { ...model, id: "gemini-3.6-flash", maxTokens: 65536 },
@@ -797,7 +798,8 @@ const flash36 = buildRequest(
   { reasoning: "medium" },
   "gemini-3.6-flash-medium",
 );
-assert.equal(flash36.request.generationConfig?.thinkingConfig?.thinkingLevel, "MEDIUM");
+assert.equal(flash36.request.generationConfig?.thinkingConfig?.thinkingBudget, 4000);
+assert.equal(flash36.request.generationConfig?.thinkingConfig?.includeThoughts, true);
 
 const flash37Off = buildRequest(
   flash37Model,
@@ -807,7 +809,7 @@ const flash37Off = buildRequest(
   "gemini-3.7-flash-low",
 );
 assert.equal(flash37Off.request.generationConfig?.thinkingConfig?.includeThoughts, false);
-assert.equal(flash37Off.request.generationConfig?.thinkingConfig?.thinkingLevel, undefined);
+assert.equal(flash37Off.request.generationConfig?.thinkingConfig?.thinkingBudget, 0);
 
 const flash35 = buildRequest(
   { ...model, id: "gemini-3.5-flash", maxTokens: 65536 },
@@ -819,6 +821,27 @@ const flash35 = buildRequest(
 assert.equal(flash35.request.generationConfig?.thinkingConfig?.thinkingBudget, 4000);
 assert.match(flash35.requestId, /^agent\//);
 assert.ok(flash35.request.labels?.trajectory_id);
+
+const claudeReq = buildRequest(
+  model,
+  dummyContext,
+  "test-proj",
+  { reasoning: "high" },
+  "claude-sonnet-4-6",
+);
+assert.equal(claudeReq.request.generationConfig?.thinkingConfig?.thinkingBudget, 1024);
+assert.equal(claudeReq.request.generationConfig?.thinkingConfig?.includeThoughts, true);
+
+const gptOssModel = { ...model, id: "gpt-oss-120b", maxTokens: 32768 };
+const gptOssReq = buildRequest(
+  gptOssModel,
+  dummyContext,
+  "test-proj",
+  { reasoning: "medium" },
+  "gpt-oss-120b-medium",
+);
+assert.equal(gptOssReq.request.generationConfig?.thinkingConfig?.thinkingBudget, 8192);
+assert.equal(gptOssReq.request.generationConfig?.thinkingConfig?.includeThoughts, true);
 
 const zeroUsage = {
   input: 0,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -13,6 +13,7 @@ import { assertSafeApiBaseUrl, safeError } from "../utils/security.js";
 import type { AntigravityApiKey, AvailableModelsRaw, DynamicModelInfo } from "../types/types.js";
 import { antigravityEnv, asString, escapeRegExp, isRecord } from "../utils/util.js";
 import { antigravityFetch } from "../utils/http.js";
+import { registerDiscoveredModelEnums, registerModelEnum } from "../models/models.js";
 
 export const DEFAULT_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 export const ENDPOINT_FALLBACKS = [
@@ -238,11 +239,16 @@ function dynamicModelFromInfo(modelId: string, info: unknown): DynamicModelInfo 
   const experiments = Array.isArray(info.modelExperiments)
     ? info.modelExperiments.filter((item): item is string => typeof item === "string")
     : undefined;
+  const modelEnum = asString(info.model);
+  if (modelEnum) {
+    registerModelEnum(modelId, modelEnum);
+  }
   return {
     id: modelId,
     experiments,
     apiProvider: asString(info.apiProvider),
     modelProvider: asString(info.modelProvider),
+    model: modelEnum,
   };
 }
 
@@ -320,6 +326,9 @@ async function fetchAvailableRuntimeModelUncached(
       if (!res.ok) continue;
       setLastEndpoint(endpoint);
       const data: unknown = await res.json();
+      if (isRecord(data) && isRecord(data.models)) {
+        registerDiscoveredModelEnums(data.models as Record<string, { model?: unknown }>);
+      }
       const labels = [...new Set(collectModelLabels(data))].slice(0, 16);
       if (labels.length) lastLabels = labels.join(",");
       const found = findDynamicModel(data, requestedRuntimeModel);
@@ -375,13 +384,6 @@ export function clearModelCache(): void {
   modelCache.clear();
 }
 
-function jsonHeaders(token: string): Record<string, string> {
-  return {
-    ...antigravityHeaders(token),
-    Accept: "application/json",
-  };
-}
-
 async function fetchAvailableModelsFromEndpoint(
   endpoint: string,
   token: string,
@@ -391,7 +393,7 @@ async function fetchAvailableModelsFromEndpoint(
   try {
     const res = await antigravityFetch(`${endpoint}/v1internal:fetchAvailableModels`, {
       method: "POST",
-      headers: jsonHeaders(token),
+      headers: antigravityHeaders(token),
       body: JSON.stringify({ project: projectId }),
       signal: catalogSignal(signal),
     });
@@ -441,6 +443,7 @@ export function mergeAvailableModelsResults(
     const data = result.data;
     if (isRecord(data) && isRecord(data.models)) {
       Object.assign(mergedModels, data.models);
+      registerDiscoveredModelEnums(data.models as Record<string, { model?: unknown }>);
     }
     if (isRecord(data) && typeof data.defaultAgentModelId === "string") {
       defaultAgentModelId = data.defaultAgentModelId;

--- a/src/models/discovery.ts
+++ b/src/models/discovery.ts
@@ -9,6 +9,7 @@ import {
   applyAntigravityCatalog,
   getCurrentAntigravityCatalog,
   PROVIDER_ID,
+  registerDiscoveredModelEnums,
 } from "./models.js";
 import { isUsableCatalog, readCatalogCache, writeCatalogCache } from "./cache.js";
 import { buildAntigravityCatalog, resolvedCatalog, type AntigravityCatalog } from "./grouping.js";
@@ -52,6 +53,7 @@ export async function discoverAntigravityModels(
   if (!models || Object.keys(models).length === 0) {
     return { models: [], routing: {} };
   }
+  registerDiscoveredModelEnums(models);
   return buildAntigravityCatalog(models, fallbackCatalog());
 }
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -385,12 +385,72 @@ export type ThinkingWire = {
 };
 
 export const ANTIGRAVITY_MODEL_ENUM: Record<string, string> = {
+  // Gemini 3.8 Flash
+  "gemini-3.8-flash": "MODEL_PLACEHOLDER_M318",
+  "gemini-3.8-flash-high": "MODEL_PLACEHOLDER_M318",
+  "gemini-3.8-flash-medium": "MODEL_PLACEHOLDER_M319",
+  "gemini-3.8-flash-low": "MODEL_PLACEHOLDER_M320",
+  "gemini-3.8-flash-tiered": "MODEL_PLACEHOLDER_M322",
+  // Gemini 3.7 Flash
+  "gemini-3.7-flash": "MODEL_PLACEHOLDER_M298",
+  "gemini-3.7-flash-high": "MODEL_PLACEHOLDER_M298",
+  "gemini-3.7-flash-medium": "MODEL_PLACEHOLDER_M299",
+  "gemini-3.7-flash-low": "MODEL_PLACEHOLDER_M300",
+  "gemini-3.7-flash-tiered": "MODEL_PLACEHOLDER_M301",
+  // Gemini 3.6 Flash
+  "gemini-3.6-flash": "MODEL_PLACEHOLDER_M71",
+  "gemini-3.6-flash-high": "MODEL_PLACEHOLDER_M71",
+  "gemini-3.6-flash-medium": "MODEL_PLACEHOLDER_M72",
+  "gemini-3.6-flash-low": "MODEL_PLACEHOLDER_M73",
+  "gemini-3.6-flash-tiered": "MODEL_PLACEHOLDER_M196",
+  // Gemini 3.5 Flash
+  "gemini-3.5-flash": "MODEL_PLACEHOLDER_M20",
   "gemini-3.5-flash-extra-low": "MODEL_PLACEHOLDER_M187",
   "gemini-3.5-flash-low": "MODEL_PLACEHOLDER_M20",
-  "gemini-3-flash-agent": "MODEL_PLACEHOLDER_M132",
+  "gemini-3-flash-agent": "MODEL_PLACEHOLDER_M84",
+  // Gemini 3.1 Pro
+  "gemini-3.1-pro": "MODEL_PLACEHOLDER_M36",
   "gemini-3.1-pro-low": "MODEL_PLACEHOLDER_M36",
+  "gemini-3.1-pro-high": "MODEL_PLACEHOLDER_M37",
   "gemini-pro-agent": "MODEL_PLACEHOLDER_M16",
+  // Claude
+  "claude-sonnet-4-6": "MODEL_PLACEHOLDER_M35",
+  "claude-opus-4-6": "MODEL_PLACEHOLDER_M26",
+  "claude-opus-4-6-thinking": "MODEL_PLACEHOLDER_M26",
+  // GPT-OSS
+  "gpt-oss-120b": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM",
+  "gpt-oss-120b-medium": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM",
 };
+
+const modelEnumCache = new Map<string, string>();
+
+/** Register dynamically discovered model enum (e.g. from fetchAvailableModels). */
+export function registerModelEnum(wireModelId: string, modelEnum: string): void {
+  if (wireModelId && modelEnum) {
+    modelEnumCache.set(wireModelId, modelEnum);
+  }
+}
+
+/** Register batch of discovered model enums from fetchAvailableModels raw models dictionary. */
+export function registerDiscoveredModelEnums(
+  models: Record<string, { model?: unknown }> | undefined,
+): void {
+  if (!models) return;
+  for (const [wireId, info] of Object.entries(models)) {
+    if (typeof info?.model === "string" && info.model) {
+      modelEnumCache.set(wireId, info.model);
+    }
+  }
+}
+
+/** Get model_enum label for a given wire model id (dynamic cache first, then static fallback). */
+export function getModelEnum(wireModelId: string): string | undefined {
+  return modelEnumCache.get(wireModelId) || ANTIGRAVITY_MODEL_ENUM[wireModelId];
+}
+
+export function clearModelEnumCache(): void {
+  modelEnumCache.clear();
+}
 
 function googleLevel(effort: string | undefined): GeminiThinkingLevel {
   if (effort === "high" || effort === "xhigh") return "HIGH";

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -1,5 +1,5 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
-import type { AntigravityRouting } from "../types/types.js";
+import type { AntigravityRouting, ThinkingWire } from "../types/types.js";
 import { ThinkingEffort } from "../types/enums.js";
 import type { AntigravityCatalog } from "./grouping.js";
 
@@ -376,13 +376,7 @@ export function getFallbackRuntimeModel(runtimeModel: string, effort?: string): 
   return undefined;
 }
 
-export type GeminiThinkingLevel = "MINIMAL" | "LOW" | "MEDIUM" | "HIGH";
-
-export type ThinkingWire = {
-  includeThoughts: boolean;
-  thinkingLevel?: GeminiThinkingLevel;
-  thinkingBudget?: number;
-};
+export type { ThinkingWire };
 
 export const ANTIGRAVITY_MODEL_ENUM: Record<string, string> = {
   "gemini-3.5-flash-extra-low": "MODEL_PLACEHOLDER_M187",
@@ -392,16 +386,18 @@ export const ANTIGRAVITY_MODEL_ENUM: Record<string, string> = {
   "gemini-pro-agent": "MODEL_PLACEHOLDER_M16",
 };
 
-function googleLevel(effort: string | undefined): GeminiThinkingLevel {
-  if (effort === "high" || effort === "xhigh") return "HIGH";
-  if (effort === "medium") return "MEDIUM";
-  return "LOW";
-}
-
 export function getThinkingConfig(
   modelId: string,
   effort: string | undefined,
 ): ThinkingWire | undefined {
+  if (modelId.startsWith("claude-")) {
+    if (!effort || effort === "off") return { includeThoughts: false, thinkingBudget: 0 };
+    return { includeThoughts: true, thinkingBudget: 1024 };
+  }
+  if (modelId.startsWith("gpt-oss-")) {
+    if (!effort || effort === "off") return { includeThoughts: false, thinkingBudget: 0 };
+    return { includeThoughts: true, thinkingBudget: 8192 };
+  }
   if (modelId === "gemini-3.5-flash") {
     if (!effort || effort === "off") return { includeThoughts: false, thinkingBudget: 0 };
     const thinkingBudget =
@@ -416,8 +412,10 @@ export function getThinkingConfig(
     };
   }
   if (modelId.startsWith("gemini-")) {
-    if (!effort || effort === "off") return { includeThoughts: false };
-    return { includeThoughts: true, thinkingLevel: googleLevel(effort) };
+    if (!effort || effort === "off") return { includeThoughts: false, thinkingBudget: 0 };
+    const thinkingBudget =
+      effort === "high" || effort === "xhigh" ? -1 : effort === "medium" ? 4_000 : 1_000;
+    return { includeThoughts: true, thinkingBudget };
   }
   return undefined;
 }

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -68,6 +68,7 @@ import {
   antigravityEnv,
   antigravityRequestEnvelope,
   isRecord,
+  resolveSessionTrajectory,
   sanitizeText,
 } from "../utils/util.js";
 import { antigravityFetch } from "../utils/http.js";
@@ -760,7 +761,32 @@ export function buildRequest(
     };
   }
 
-  const envelope = antigravityRequestEnvelope(runtimeModel, isClaude);
+  const isNonGemini =
+    isClaude ||
+    model.id.startsWith("gpt-oss-") ||
+    runtimeModel.startsWith("gpt-oss-") ||
+    (!model.id.startsWith("gemini-") && !runtimeModel.startsWith("gemini-"));
+
+  // Pure agy CLI wire alignment:
+  // - step in requestId (.../<step>) equals contents.length (total content blocks)
+  // - last_step_index is 0-based index of the last content block (contents.length - 1)
+  // - request_id is ${trajectoryId}-${requestIndex} (0-based HTTP request sequence counter)
+  //   In multi-turn agent loops (with tools), every completed assistant response increments the request counter.
+  const step = Math.max(1, request.contents.length);
+  const lastStepIndex = String(Math.max(0, request.contents.length - 1));
+  const requestIndex = context.messages?.filter((m) => m.role === "assistant").length ?? 0;
+
+  const { conversationId, trajectoryId } = resolveSessionTrajectory(context);
+
+  const envelope = antigravityRequestEnvelope(runtimeModel, {
+    isClaude,
+    isNonGemini,
+    step,
+    lastStepIndex,
+    requestIndex,
+    conversationId,
+    trajectoryId,
+  });
   request.sessionId = options.sessionId || envelope.sessionId;
   request.labels = envelope.labels;
 
@@ -1083,11 +1109,7 @@ export function streamAntigravity(
         runtimeCandidates.push(fallback);
       }
 
-      const isClaudeReasoning = model.id.startsWith("claude-") && model.reasoning;
-      const requestHeaders: Record<string, string> = {
-        ...antigravityHeaders(creds.token),
-        ...(isClaudeReasoning ? { "anthropic-beta": "interleaved-thinking-2025-05-14" } : {}),
-      };
+      const requestHeaders = antigravityHeaders(creds.token);
 
       let response: Response | undefined;
       let lastText = "";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -50,8 +50,8 @@ export type AntigravityRouting = {
 export const ANTIGRAVITY_API = "antigravity-api" as const;
 export type AntigravityApi = typeof ANTIGRAVITY_API;
 
-export type AntigravityStreamOptions = SimpleStreamOptions & {
-  toolChoice?: ToolChoice;
+export type AntigravityStreamOptions = Omit<SimpleStreamOptions, "toolChoice"> & {
+  toolChoice?: ToolChoice | `${ToolChoice}`;
 };
 
 export type GeminiTextPart = { text: string; thoughtSignature?: string };
@@ -101,14 +101,15 @@ export type GeminiToolConfig = {
   };
 };
 
+export type ThinkingWire = {
+  includeThoughts: boolean;
+  thinkingBudget: number;
+};
+
 export type GeminiGenerationConfig = {
   temperature?: number;
   maxOutputTokens?: number;
-  thinkingConfig?: {
-    includeThoughts?: boolean;
-    thinkingLevel?: "MINIMAL" | "LOW" | "MEDIUM" | "HIGH";
-    thinkingBudget?: number;
-  };
+  thinkingConfig?: ThinkingWire;
 };
 
 export type GeminiRequestBody = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,7 @@ export type DynamicModelInfo = {
   experiments?: string[];
   apiProvider?: string;
   modelProvider?: string;
+  model?: string;
 };
 
 export type CallbackServer = {
@@ -50,8 +51,8 @@ export type AntigravityRouting = {
 export const ANTIGRAVITY_API = "antigravity-api" as const;
 export type AntigravityApi = typeof ANTIGRAVITY_API;
 
-export type AntigravityStreamOptions = SimpleStreamOptions & {
-  toolChoice?: ToolChoice;
+export type AntigravityStreamOptions = Omit<SimpleStreamOptions, "toolChoice"> & {
+  toolChoice?: ToolChoice | `${ToolChoice}`;
 };
 
 export type GeminiTextPart = { text: string; thoughtSignature?: string };
@@ -260,6 +261,7 @@ export type ModelInfoRaw = {
   displayName?: unknown;
   label?: unknown;
   modelName?: unknown;
+  model?: unknown;
   modelProvider?: unknown;
   apiProvider?: unknown;
   supportsThinking?: unknown;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,4 +1,5 @@
-import { ANTIGRAVITY_MODEL_ENUM } from "../models/models.js";
+import { createHash } from "node:crypto";
+import { getModelEnum } from "../models/models.js";
 
 export function antigravityEnv(name: string): string | undefined {
   return process.env[`ANTIGRAVITY_${name}`] || process.env[`NOAGY_${name}`];
@@ -33,24 +34,96 @@ export function nowRequestId(): string {
   return antigravityRequestEnvelope("unknown", false).requestId;
 }
 
+/** Deterministic RFC 4122 v5 UUID from seed (survives restarts for the same session seed). */
+export function stableUuid(seed: string): string {
+  const bytes = createHash("sha1").update(seed).digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export type AntigravityEnvelopeOptions = {
+  isClaude?: boolean;
+  isNonGemini?: boolean;
+  step?: number;
+  lastStepIndex?: string;
+  requestIndex?: number;
+  userTurnIndex?: number;
+  trajectoryId?: string;
+  conversationId?: string;
+};
+
+const sessionTrajectoryMap = new Map<string, { conversationId: string; trajectoryId: string }>();
+
+/** Stable conversationId and trajectoryId within a multi-turn conversation session. */
+export function resolveSessionTrajectory(context?: {
+  messages?: Array<{ role?: string; timestamp?: number; content?: unknown }>;
+}): { conversationId: string; trajectoryId: string } {
+  const firstMsg = context?.messages?.[0];
+  if (!firstMsg) {
+    return { conversationId: crypto.randomUUID(), trajectoryId: crypto.randomUUID() };
+  }
+  const contentSeed =
+    typeof firstMsg.content === "string"
+      ? firstMsg.content.slice(0, 64)
+      : Array.isArray(firstMsg.content)
+        ? JSON.stringify(firstMsg.content[0] ?? "").slice(0, 64)
+        : "";
+  const seed = `${firstMsg.role || "user"}:${firstMsg.timestamp || ""}:${contentSeed}`;
+  let entry = sessionTrajectoryMap.get(seed);
+  if (!entry) {
+    entry = {
+      conversationId: stableUuid(`antigravity:conv:${seed}`),
+      trajectoryId: stableUuid(`antigravity:traj:${seed}`),
+    };
+    sessionTrajectoryMap.set(seed, entry);
+    if (sessionTrajectoryMap.size > 64) {
+      const oldestKey = sessionTrajectoryMap.keys().next().value;
+      if (oldestKey !== undefined) sessionTrajectoryMap.delete(oldestKey);
+    }
+  }
+  return entry;
+}
+
+export function clearSessionTrajectoryMap(): void {
+  sessionTrajectoryMap.clear();
+}
+
 export function antigravityRequestEnvelope(
   wireModelId: string,
-  isClaude: boolean,
+  optionsOrIsClaude: boolean | AntigravityEnvelopeOptions = false,
 ): { requestId: string; sessionId: string; labels: Record<string, string> } {
-  const agentId = crypto.randomUUID();
-  const trajectoryId = crypto.randomUUID();
-  const step = 2;
+  const options: AntigravityEnvelopeOptions =
+    typeof optionsOrIsClaude === "boolean" ? { isClaude: optionsOrIsClaude } : optionsOrIsClaude;
+
+  const isClaude = Boolean(options.isClaude);
+  const isNonGemini = Boolean(options.isNonGemini || isClaude);
+  const step = Math.max(1, options.step ?? 1);
+  const lastStepIndex = options.lastStepIndex ?? String(Math.max(0, step - 1));
+  const requestIndex = options.requestIndex ?? options.userTurnIndex ?? Math.max(0, step - 1);
+  const agentId = options.conversationId || crypto.randomUUID();
+  const trajectoryId = options.trajectoryId || crypto.randomUUID();
   const bytes = crypto.getRandomValues(new Uint8Array(8));
   const sessionId = String(new DataView(bytes.buffer, bytes.byteOffset, 8).getBigInt64(0, true));
-  const usageLabel = isClaude ? "true" : "false";
+
+  const claudeLabel = isClaude ? "true" : "false";
+  const nonGeminiLabel = isNonGemini ? "true" : "false";
+
   const labels: Record<string, string> = {
-    last_step_index: String(step - 1),
+    last_step_index: lastStepIndex,
+    request_id: `${trajectoryId}-${requestIndex}`,
     trajectory_id: trajectoryId,
-    used_claude: usageLabel,
-    used_claude_conservative: usageLabel,
+    used_claude: claudeLabel,
+    used_claude_conservative: claudeLabel,
+    used_non_gemini_model: nonGeminiLabel,
   };
-  const modelEnum = ANTIGRAVITY_MODEL_ENUM[wireModelId];
-  if (modelEnum) labels.model_enum = modelEnum;
+
+  const modelEnum = getModelEnum(wireModelId);
+  if (modelEnum) {
+    labels.model_enum = modelEnum;
+  }
+
   return {
     requestId: `agent/${agentId}/${Date.now()}/${trajectoryId}/${step}`,
     sessionId,


### PR DESCRIPTION
## Summary

Aligns `request.labels`, top-level `requestId`, dynamic `model_enum` resolution, and request headers with the official Google Antigravity CLI (`agy` v1.1.23, CL: 974125021) based on end-to-end network traffic capture and wire packet inspection.

---

## Background & Ground-Truth Network Inspection

To ensure `pi-antigravity` emits a network wire fingerprint completely indistinguishable from the official `agy` CLI, we captured and analyzed live HTTP traffic (`/v1internal:streamGenerateContent` and `/v1internal:fetchAvailableModels`) across single-turn, multi-turn, and interactive tool-calling loops.

### Wire Discrepancies Uncovered in Prior Implementation

| Dimension | Pure `agy` CLI (Wire Inspection) | Prior `pi-antigravity` | Status in this PR |
|---|---|---|:---:|
| **`labels.request_id`** | `${trajectory_id}-${request_index}` (`...-0`, `...-1`, `...-2`) | *Omitted entirely* | **Fixed** |
| **`labels.last_step_index`** | `String(contents.length - 1)` (0-based, starts at `"0"`) | Hardcoded `"1"` | **Fixed** |
| **`requestId` format** | `agent/<conv_id>/<epoch>/<traj_id>/${contents.length}` (starts at `/1`) | Hardcoded ending `/2` | **Fixed** |
| **`labels.used_non_gemini_model`** | `"true"` for Claude/GPT-OSS, `"false"` for Gemini | *Omitted entirely* | **Fixed** |
| **`labels.model_enum`** | Dynamically extracted from `/v1internal:fetchAvailableModels` `model` field | Only 5 legacy 3.5 models hardcoded | **Fixed** |
| **`anthropic-beta` Header** | *Never sent* (only body `thinkingConfig` is sent) | Sent `interleaved-thinking-2025-05-14` on Claude reasoning | **Removed** |
| **`Accept` Header on Discovery** | *Never sent* (`antigravityHeaders` only) | Injected `Accept: application/json` | **Removed** |

---

### Empirical Evidence from Multi-turn & Tool Calling Capture

Inspection of a 3-turn interactive conversation including bash command tool execution (`agy -p ... --dangerously-skip-permissions` followed by `agy -c ...`) revealed the exact sequence rules:

```text
Turn 1 (Prompt 1) -> API CALL #1: contents=[user] (len: 1)
  -> requestId: agent/<conv>/<ts>/<traj>/1
  -> labels: { last_step_index: "0", request_id: "<traj>-0", trajectory_id: "<traj>", ... }

Turn 1 (Tool Result) -> API CALL #2: contents=[user, model(call), model(result)] (len: 3)
  -> requestId: agent/<conv>/<ts>/<traj>/3
  -> labels: { last_step_index: "2", request_id: "<traj>-1", trajectory_id: "<traj>", ... }

Turn 2 (Prompt 2) -> API CALL #3: contents=[..., user, sys] (len: 6)
  -> requestId: agent/<conv>/<ts>/<traj>/6
  -> labels: { last_step_index: "5", request_id: "<traj>-2", trajectory_id: "<traj>", ... }

Turn 2 (Tool Result) -> API CALL #4: contents=[..., model(call), model(result)] (len: 8)
  -> requestId: agent/<conv>/<ts>/<traj>/8
  -> labels: { last_step_index: "7", request_id: "<traj>-3", trajectory_id: "<traj>", ... }
```

**Key Findings:**
1. **`request_id` Sequence**: Increments on *every* outgoing `streamGenerateContent` request (`<traj>-0`, `<traj>-1`, `<traj>-2`...). In agent loops with tool calls, this corresponds exactly to the number of completed `assistant` turns (`context.messages.filter(m => m.role === "assistant").length`).
2. **`last_step_index` & Top-level Step**: The step in `requestId` is strictly the length of `request.contents`, and `last_step_index` is `String(contents.length - 1)`. This guarantees indexing consistency even when older turns are compacted.
3. **`trajectory_id` & `conversation_id` Stability**: Persists across the entire multi-turn session.

---

## Changes

### 1. Request Envelope & Labels Normalization (`src/utils/util.ts`, `src/stream/stream.ts`)
- **`request.labels.request_id`**: Set to `${trajectory_id}-${requestIndex}` where `requestIndex` is `context.messages.filter(m => m.role === "assistant").length` (0-based request counter).
- **`step` & `last_step_index`**: Derived directly from `request.contents.length` (`step = contents.length`, `last_step_index = String(contents.length - 1)`).
- **`labels.used_non_gemini_model`**: Added `"true"` for non-Gemini models (Claude, GPT-OSS) and `"false"` for Gemini.
- **Process-Restart Resilient `trajectory_id`**: Added `resolveSessionTrajectory()` generating deterministic RFC 4122 v5 UUIDs from the conversation's initial message seed, preserving stable `trajectory_id` and `conversationId` across Pi process restarts and `/resume`.
- **Backwards-Compatible Signature**: `antigravityRequestEnvelope(wireModelId, optionsOrIsClaude)` preserves existing boolean call compatibility.

### 2. Dynamic `model_enum` Extraction & Static Fallbacks (`src/models/models.ts`, `src/client/client.ts`, `src/models/discovery.ts`)
- In `ModelInfoRaw` and `DynamicModelInfo`, typed the `model?: unknown` field returned by `/v1internal:fetchAvailableModels`.
- Extracted and cached backend model enums dynamically during catalog discovery (`registerDiscoveredModelEnums`).
- Added static fallback entries in `ANTIGRAVITY_MODEL_ENUM` for all 14 official `agy` models (Gemini 3.8/3.7/3.6 Flash, Gemini 3.1 Pro, Claude Sonnet/Opus, GPT-OSS 120B) for offline/pre-discovery requests.

### 3. Residual Non-Standard Header Elimination (`src/stream/stream.ts`, `src/client/client.ts`)
- Removed `anthropic-beta: interleaved-thinking-2025-05-14` injection during Claude reasoning in `src/stream/stream.ts`. Wire captures confirm pure `agy` CLI never sends Anthropic-specific beta headers to Cloud Code Assist.
- Removed `Accept: application/json` in `src/client/client.ts` during model discovery, unifying all outbound calls under `antigravityHeaders()`.
- Updated test/smoke scripts (`smoke-all-models.mjs`, `smoke-tool-schema.ts`, `smoke-sonnet.mjs`) accordingly.

---

## Validation

- [x] **Network traffic captured and diffed** against live CLI sessions of pure `agy` CLI v1.1.23 across single-turn, multi-turn, and tool call sequences.
- [x] **Comprehensive unit tests added** in `scripts/test-model-routing.ts` verifying:
  - 7 wire label fields across Gemini 3.8/3.7/3.6, Gemini Pro, Claude Sonnet/Opus, and GPT-OSS
  - Tool execution loops incrementing `request_id` sequence (`-0`, `-1`, `-2`...)
  - Deterministic `trajectory_id` survival across in-memory cache eviction (process restarts)
- [x] **Discovery tests added** in `scripts/test-model-discovery.ts` verifying dynamic `model_enum` registration and absence of `Accept: application/json`.
- [x] **Full test suite passes**: `bun run check` (typecheck, lint, format, security-check, 6 test scripts).

## Security

- [x] No credentials, tokens, or private secrets included.
- [x] Deterministic UUID generation utilizes SHA-1 purely for non-cryptographic namespace identification (RFC 4122 v5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded model discovery and routing for Gemini, Claude, and GPT models.
  - Dynamically discovered models are now recognized automatically.
  - Multi-turn sessions maintain stable conversation and trajectory tracking.
  - Stream options accept structured or string-form tool choices.

- **Bug Fixes**
  - Improved model-specific request labeling and routing accuracy.
  - Standardized request headers across supported model workflows.
  - Unified thinking configuration across supported models using model-specific budgets.
  - Improved request metadata for more consistent multi-turn behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Incorporated from #36 (closed as superseded): integer `thinkingBudget` for all models

This branch now includes the full contents of #36 (`fix/thinking-budget`, merged locally with conflicts resolved), so #39 is a superset and #36 is closed without merging.

### Thinking config changes (`src/types/types.ts`, `src/models/models.ts`)
- `ThinkingWire` is now `{ includeThoughts: boolean; thinkingBudget: number }`; the deprecated `thinkingLevel` string enum (`"MINIMAL" | "LOW" | "MEDIUM" | "HIGH"`) is removed.
- `getThinkingConfig()` returns integer budgets matching `agy` v1.1.23 wire captures and discovery metadata:
  - **Gemini 3.8 / 3.7 / 3.6 Flash**: high/xhigh `-1`, medium `4000`, low `1000`, off `0`
  - **Gemini 3.5 Flash**: high/xhigh `10000`, medium `4000`, low `1000`, off `0`
  - **Gemini 3.1 Pro**: high/xhigh `10001`, low `1001`, off `0`
  - **Claude Sonnet 4.6 & Opus 4.6**: `1024`, off `0`
  - **GPT-OSS 120B**: `8192`, off `0`
- `scripts/smoke-all-models.mjs` now calls `models.getThinkingConfig(publicId, EFFORT)` instead of hardcoded per-family branches.
- `README.md` thinking-budget notes updated (3.5 values and `0`-on-off clarified).
- `scripts/test-model-routing.ts` / `test-model-discovery.ts` assertions updated from `thinkingLevel` to `thinkingBudget` for Gemini, Claude, and GPT-OSS.
- Full 14/14 wire-verification matrix and capture methodology: see #36 (closed as superseded by this PR).
