### PR TITLE
release: 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-antigravity",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Personal Antigravity / Cloud Code Assist provider for Pi Coding Agent",
   "author": "Rahul Arya",
   "license": "MIT",


### PR DESCRIPTION
## Release
Bumps package version to 0.7.2 for the merged Antigravity stream, catalog persistence, and Skill-context fixes.

Validation: `bun run check`.