### PR TITLE
fix(stream): normalize trailing model turns and tool call message boundaries

### DIFF
--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -557,6 +557,14 @@ assert.match(
   /Unknown name nullable/i,
 );
 
+const trailingModelError = friendlyAntigravityError(
+  400,
+  JSON.stringify({ error: { message: "Requests ending with a model turn are not supported." } }),
+);
+assert.match(trailingModelError, /message boundary/i);
+assert.match(trailingModelError, /new session|user message/i);
+assert.ok(!/re-login/i.test(trailingModelError));
+
 assert.equal(mapStopReason("STOP"), StopReason.Stop);
 assert.equal(mapStopReason("MAX_TOKENS"), StopReason.Length);
 assert.equal(mapStopReason("OTHER"), StopReason.Error);
@@ -688,11 +696,15 @@ const consecutiveContext = {
   ],
 } as Context;
 const mergedContents = convertMessages(model, consecutiveContext, "claude-sonnet-4-6");
-assert.equal(mergedContents.length, 2);
+assert.equal(mergedContents.length, 3);
 assert.equal(mergedContents[0]?.role, "user");
 assert.equal(mergedContents[0]?.parts.length, 2);
 assert.equal(mergedContents[1]?.role, "model");
 assert.equal(mergedContents[1]?.parts.length, 2);
+assert.deepEqual(mergedContents[2], {
+  role: "user",
+  parts: [{ text: "Continue the active task using the available instructions and context." }],
+});
 
 // Test Base64 Image data URL prefix stripping
 const imageContext = {
@@ -871,6 +883,78 @@ const zeroUsage = {
 const geminiRuntime = "gemini-3.7-flash-low";
 const validSig = "QkFTRTY0LXRlc3Qtc2lnbmF0dXJlLXRlc3QxMjM0NTY=";
 
+
+const continuationText = "Continue the active task using the available instructions and context.";
+
+// A normal assistant text reply must not leave the Antigravity request ending in a model turn.
+const assistantTailContext = {
+  messages: [
+    { role: "user", content: "Summarize this file.", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "The file defines the request adapter." }],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: zeroUsage,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const assistantTailContents = convertMessages(flash37Model, assistantTailContext, geminiRuntime);
+assert.deepEqual(
+  assistantTailContents.map((turn) => turn.role),
+  ["user", "model", "user"],
+  "a text assistant tail must receive a user continuation",
+);
+assert.deepEqual(assistantTailContents[1]?.parts, [
+  { text: "The file defines the request adapter." },
+]);
+assert.deepEqual(assistantTailContents[2]?.parts, [{ text: continuationText }]);
+
+const userTailContext = {
+  messages: [
+    { role: "user", content: "First request.", timestamp: Date.now() },
+    { role: "user", content: "Second request.", timestamp: Date.now() },
+  ],
+} as Context;
+const userTailContents = convertMessages(flash37Model, userTailContext, geminiRuntime);
+assert.deepEqual(userTailContents, [
+  { role: "user", parts: [{ text: "First request." }, { text: "Second request." }] },
+]);
+
+const unresolvedToolCallContext = {
+  messages: [
+    { role: "user", content: "Read package.json.", timestamp: Date.now() },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-missing-result",
+          name: "read",
+          arguments: { path: "package.json" },
+          thoughtSignature: validSig,
+        },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: zeroUsage,
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+let unresolvedToolCallError: unknown;
+try {
+  convertMessages(flash37Model, unresolvedToolCallContext, geminiRuntime);
+} catch (error) {
+  unresolvedToolCallError = error;
+}
+assert.ok(unresolvedToolCallError instanceof Error);
+assert.match(unresolvedToolCallError.message, /missing tool result/i);
 const multimodalResultContext = {
   messages: [
     { role: "user", content: "take screenshot", timestamp: Date.now() },

--- a/scripts/test-model-routing.ts
+++ b/scripts/test-model-routing.ts
@@ -565,6 +565,18 @@ assert.match(trailingModelError, /message boundary/i);
 assert.match(trailingModelError, /new session|user message/i);
 assert.ok(!/re-login/i.test(trailingModelError));
 
+const functionCallBoundaryError = friendlyAntigravityError(
+  400,
+  JSON.stringify({
+    error: {
+      message:
+        "Please ensure that function call turn comes immediately after a user turn or after a function response turn.",
+    },
+  }),
+);
+assert.match(functionCallBoundaryError, /function-call message boundary/i);
+assert.match(functionCallBoundaryError, /new session/i);
+assert.match(functionCallBoundaryError, /re-login is not required/i);
 assert.equal(mapStopReason("STOP"), StopReason.Stop);
 assert.equal(mapStopReason("MAX_TOKENS"), StopReason.Length);
 assert.equal(mapStopReason("OTHER"), StopReason.Error);
@@ -955,6 +967,52 @@ try {
 }
 assert.ok(unresolvedToolCallError instanceof Error);
 assert.match(unresolvedToolCallError.message, /missing tool result/i);
+
+// Truncated/compacted history can begin with an assistant function call. Antigravity
+// requires that call turn to have an immediately preceding user boundary.
+const leadingToolCallContext = {
+  messages: [
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-leading",
+          name: "read",
+          arguments: { path: "package.json" },
+          thoughtSignature: validSig,
+        },
+      ],
+      api: "antigravity-api",
+      provider: "antigravity",
+      model: "gemini-3.7-flash",
+      usage: zeroUsage,
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call-leading",
+      toolName: "read",
+      content: [{ type: "text", text: "package contents" }],
+      isError: false,
+      timestamp: Date.now(),
+    },
+  ],
+} as unknown as Context;
+const leadingToolCallContents = convertMessages(
+  flash37Model,
+  leadingToolCallContext,
+  geminiRuntime,
+ );
+assert.deepEqual(
+  leadingToolCallContents.map((turn) => turn.role),
+  ["user", "model", "user"],
+  "a leading function call must receive a preceding user bridge",
+);
+assert.deepEqual(leadingToolCallContents[0]?.parts, [{ text: continuationText }]);
+assert.ok(leadingToolCallContents[1]?.parts.every((part) => "functionCall" in part));
+assert.ok(leadingToolCallContents[2]?.parts.every((part) => "functionResponse" in part));
 const multimodalResultContext = {
   messages: [
     { role: "user", content: "take screenshot", timestamp: Date.now() },

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -315,6 +315,24 @@ export function convertMessages(
     }
   }
 
+  // A function-call model turn is only valid immediately after a user turn
+  // (including a function-response turn). Compacted history can drop that
+  // boundary, so restore it before applying the natural-language bridge.
+  for (let index = 0; index < contents.length; index += 1) {
+    const turn = contents[index];
+    if (
+      turn?.role === GeminiRole.Model &&
+      turn.parts.some((part) => "functionCall" in part) &&
+      contents[index - 1]?.role !== GeminiRole.User
+    ) {
+      contents.splice(index, 0, {
+        role: GeminiRole.User,
+        parts: [{ text: CONTINUATION_TEXT }],
+      });
+      index += 1;
+    }
+  }
+
   // Google Antigravity requires a natural-language user part in the request,
   // including tool-only continuation turns. Keep injected Skills in the system
   // instruction, then add this protocol bridge only when existing context gives
@@ -873,6 +891,13 @@ export function friendlyAntigravityError(status: number | undefined, text: strin
   if (status === 400) {
     if (/Requests ending with a model turn are not supported/i.test(msg)) {
       return "Antigravity rejected an invalid conversation message boundary. Next: update the extension or add a user message / start a new session, then retry.";
+    }
+    if (
+      /function call turn comes immediately after a user turn or after a function response turn/i.test(
+        msg,
+      )
+    ) {
+      return "Antigravity rejected an invalid function-call message boundary. Next: update the extension or start a new session, then retry; re-login is not required.";
     }
     if (/API key not valid|API_KEY_INVALID/i.test(msg)) {
       return "Antigravity login expired or credentials are invalid. Next: run /login antigravity, then retry.";

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -82,6 +82,7 @@ const ANTIGRAVITY_SYSTEM_INSTRUCTION =
 const ANTIGRAVITY_NO_PREAMBLE_INSTRUCTION =
   'CRITICAL: NEVER output rule checks, formatting guidelines, constraint checklists (e.g. "No emdashes"), or your thinking/personality preambles in the final response. Output only the final response.';
 
+const CONTINUATION_TEXT = "Continue the active task using the available instructions and context.";
 let toolCallCounter = 0;
 
 function sanitizeToolCallId(id: string, fallbackName?: string): string {
@@ -325,11 +326,21 @@ export function convertMessages(
   );
   if (!hasUserText && contents.length > 0) {
     const bridge = {
-      text: "Continue the active task using the available instructions and context.",
+      text: CONTINUATION_TEXT,
     };
     const userTurn = contents.find((turn) => turn.role === GeminiRole.User);
     if (userTurn) userTurn.parts.push(bridge);
     else contents.unshift({ role: GeminiRole.User, parts: [bridge] });
+  }
+
+  const lastTurn = contents.at(-1);
+  if (lastTurn?.role === GeminiRole.Model) {
+    if (lastTurn.parts.some((part) => "functionCall" in part)) {
+      throw new Error(
+        "Antigravity request is missing tool result(s) for the final assistant tool call. Provide the corresponding tool result before continuing.",
+      );
+    }
+    appendTurn(contents, GeminiRole.User, [{ text: CONTINUATION_TEXT }]);
   }
 
   return contents;
@@ -860,6 +871,9 @@ export function mapStopReason(reason: string | undefined): StopReason {
 export function friendlyAntigravityError(status: number | undefined, text: string): string {
   const msg = redactSecrets(jsonOrTextError(text)).slice(0, 500);
   if (status === 400) {
+    if (/Requests ending with a model turn are not supported/i.test(msg)) {
+      return "Antigravity rejected an invalid conversation message boundary. Next: update the extension or add a user message / start a new session, then retry.";
+    }
     if (/API key not valid|API_KEY_INVALID/i.test(msg)) {
       return "Antigravity login expired or credentials are invalid. Next: run /login antigravity, then retry.";
     }


### PR DESCRIPTION
# Pull request

## Summary

Resolves 400 errors returned by the Antigravity upstream API caused by invalid conversation message boundaries, specifically around compacted/truncated history and trailing model turns.

### Background & Root Cause
1. **Leading/Orphan Function Calls**: When conversation history is compacted or truncated by the harness, an assistant turn containing `functionCall` can end up at the very start of the history or immediately following a non-user turn. Antigravity strictly enforces:
   > *"Please ensure that function call turn comes immediately after a user turn or after a function response turn."*
2. **Trailing Model Turns**: When a conversation ends with an assistant text turn, Antigravity rejects the request with:
   > *"Requests ending with a model turn are not supported."*
3. **Unclear 400 Errors**: Previously, users hitting these boundary errors often assumed their session/OAuth credentials had expired and attempted repeated `/login antigravity`, which did not solve the issue.

### Changes
1. **Enforce Preceding User Boundary for Function Calls (`src/stream/stream.ts`)**:
   - Iterates through converted contents and inserts a user continuation bridge (`CONTINUATION_TEXT`) before any model turn containing `functionCall` if it does not immediately follow a `user` turn.
2. **Handle Trailing Model Turns (`src/stream/stream.ts`)**:
   - If the request ends with an assistant text turn, automatically appends a user continuation turn.
   - If the request ends with an unfulfilled `functionCall` (missing tool results), early-throws a clear, actionable error before sending the request upstream.
3. **Actionable 400 Error Guidance (`src/stream/stream.ts`)**:
   - Added regex matching in `friendlyAntigravityError()` for both `Requests ending with a model turn...` and `function call turn comes immediately after a user turn...`.
   - Explicitly informs the user to update the extension, append a message, or start a new session, and clarifies that **re-login is not required**.
4. **Unit Tests (`scripts/test-model-routing.ts`)**:
   - Added regression test cases covering leading tool calls after compaction, assistant text tails receiving user continuation, unresolved tool call rejection, and friendly 400 error message matching.

## Validation

- [x] `bun run check`
- [x] Tests added or updated when behavior changed
- [ ] Documentation updated when commands, auth, config, or models changed *(N/A: no command, auth, or model configuration changes)*

## Security

- [x] No credentials, tokens, secrets, or private account data are included
- [x] Security implications have been considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history handling when assistant tool calls appear without an immediately preceding user turn.
  * Preserved continuation context across compacted or consecutive conversation turns.
  * Added safeguards and clearer error messages for incomplete tool-call exchanges and invalid message boundaries.
  * Improved handling of assistant responses that end with tool calls, preventing requests from proceeding without the required tool result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
